### PR TITLE
Fixes for issue #308

### DIFF
--- a/src/model/IonSeries.cpp
+++ b/src/model/IonSeries.cpp
@@ -48,17 +48,17 @@ struct loss_limit{
 };
 
 // Initalize array of loss_limit objects
-void initialize_loss_limit(LOSS_LIMIT_T *array, int size) {
-  if  (size > GlobalParams::getMaxLength()) {
+void IonSeries::initialize_loss_limit() {
+  if  (peptide_length_ > GlobalParams::getMaxLength()) {
     carp(
       CARP_FATAL, 
       "Requested loss_limit array with length = %d, which exceeds the max length of %d.\n"
       "Increase the value of the max-length parameter\n",
-      size,
+      peptide_length_,
       GlobalParams::getMaxLength()
    );
   }
-  memset(array, 0, sizeof(LOSS_LIMIT_T) * size);
+  memset(loss_limit_, 0, sizeof(LOSS_LIMIT_T) * peptide_length_);
 }
 
 //Test cache for speeding up loss limit allocations
@@ -152,7 +152,7 @@ IonSeries::IonSeries(
   
   // create the loss limit array
   loss_limit_ = loss_limit_cache.checkout();
-  initialize_loss_limit(loss_limit_, peptide_length_);
+  initialize_loss_limit();
 }
 
 /**
@@ -220,7 +220,7 @@ void IonSeries::update(
   modified_aa_seq_ = (MODIFIED_AA_T*)mod_seq;
 
   // Initialize the loss limit array for the new peptide
-  initialize_loss_limit(loss_limit_, peptide_length_);
+  initialize_loss_limit();
 }
 
 int IonSeries::incrementPointerCount() {

--- a/src/model/IonSeries.cpp
+++ b/src/model/IonSeries.cpp
@@ -140,6 +140,16 @@ IonSeries::IonSeries(
   // create the loss limit array
   loss_limit_ = loss_limit_cache.checkout();
   //loss_limit_ = new LOSS_LIMIT_T[GlobalParams::getMaxLength()];
+  if  (peptide_length_ > GlobalParams::getMaxLength()) {
+    carp(
+      CARP_FATAL, 
+      "The peptide %s has length = %d, which exceeds the max length of %d.\n"
+      "Increase the value of the max-length parameter\n",
+      peptide_.c_str(),
+      peptide_length_,
+      GlobalParams::getMaxLength()
+   );
+  }
   memset(loss_limit_, 0, sizeof(LOSS_LIMIT_T) * peptide_length_);
 }
 
@@ -209,6 +219,16 @@ void IonSeries::update(
 
   // Initialize the loss limit array for the new peptide
   //carp(CARP_INFO, "loss_limit_:%d peptide_length:%d", loss_limit_, peptide_length_);
+  if  (peptide_length_ > GlobalParams::getMaxLength()) {
+    carp(
+      CARP_FATAL, 
+      "The peptide %s has length = %d, which exceeds the max length of %d.\n"
+      "Increase the value of the max-length parameter\n",
+      peptide_.c_str(),
+      peptide_length_,
+      GlobalParams::getMaxLength()
+   );
+  }
   memset(loss_limit_, 0, sizeof(LOSS_LIMIT_T) * peptide_length_);
 }
 

--- a/src/model/IonSeries.cpp
+++ b/src/model/IonSeries.cpp
@@ -47,6 +47,19 @@ struct loss_limit{
   // If change this struct, must also modify update_ion_series method
 };
 
+// Initalize array of loss_limit objects
+void initialize_loss_limit(LOSS_LIMIT_T *array, int size) {
+  if  (size > GlobalParams::getMaxLength()) {
+    carp(
+      CARP_FATAL, 
+      "Requested loss_limit array with length = %d, which exceeds the max length of %d.\n"
+      "Increase the value of the max-length parameter\n",
+      size,
+      GlobalParams::getMaxLength()
+   );
+  }
+  memset(array, 0, sizeof(LOSS_LIMIT_T) * size);
+}
 
 //Test cache for speeding up loss limit allocations
 class LossLimitCache {
@@ -139,18 +152,7 @@ IonSeries::IonSeries(
   
   // create the loss limit array
   loss_limit_ = loss_limit_cache.checkout();
-  //loss_limit_ = new LOSS_LIMIT_T[GlobalParams::getMaxLength()];
-  if  (peptide_length_ > GlobalParams::getMaxLength()) {
-    carp(
-      CARP_FATAL, 
-      "The peptide %s has length = %d, which exceeds the max length of %d.\n"
-      "Increase the value of the max-length parameter\n",
-      peptide_.c_str(),
-      peptide_length_,
-      GlobalParams::getMaxLength()
-   );
-  }
-  memset(loss_limit_, 0, sizeof(LOSS_LIMIT_T) * peptide_length_);
+  initialize_loss_limit(loss_limit_, peptide_length_);
 }
 
 /**
@@ -218,18 +220,7 @@ void IonSeries::update(
   modified_aa_seq_ = (MODIFIED_AA_T*)mod_seq;
 
   // Initialize the loss limit array for the new peptide
-  //carp(CARP_INFO, "loss_limit_:%d peptide_length:%d", loss_limit_, peptide_length_);
-  if  (peptide_length_ > GlobalParams::getMaxLength()) {
-    carp(
-      CARP_FATAL, 
-      "The peptide %s has length = %d, which exceeds the max length of %d.\n"
-      "Increase the value of the max-length parameter\n",
-      peptide_.c_str(),
-      peptide_length_,
-      GlobalParams::getMaxLength()
-   );
-  }
-  memset(loss_limit_, 0, sizeof(LOSS_LIMIT_T) * peptide_length_);
+  initialize_loss_limit(loss_limit_, peptide_length_);
 }
 
 int IonSeries::incrementPointerCount() {

--- a/src/model/Protein.cpp
+++ b/src/model/Protein.cpp
@@ -214,7 +214,7 @@ int Protein::findStart(
   string seq = prev_aa + peptide_sequence + next_aa;
   size_t pos = protein_seq.find(seq);
   if (pos != string::npos) {
-    return pos + 2;
+    return pos + prev_aa.length() + 1;
   }
   // failed, find sequence
   seq = peptide_sequence;


### PR DESCRIPTION


This pull request fixes two problems underlying issue #308.

The first problem was that when creating an array, IonSeries.cpp was not checking the size of peptide to be put in the array vs. the maximum allowable size of the array. I added code to perform that test, and to issue a FATAL error if the peptide exceeded the maximum allowed size.

The second problem was that Protein::findStart() accepted two arguments, prev_aa and next_aa, which could be used to set the symbols that should occur immediately before and after the sequence being searched for. However the body of the code assumed that these strings would always be of length 1. If empty strings were passed in, the returned offset of the sequence would be off by 1.

Sample data files and script for demonstrating issues found at ~cegrant/issue-308.tar.gz