### PR TITLE
Added commit date to version

### DIFF
--- a/make-version-header.cmake
+++ b/make-version-header.cmake
@@ -1,6 +1,7 @@
 set(CRUX_VERSION_FULL "${CRUX_VERSION}")
 
 if (EXISTS "${SOURCE_DIR}/.git/HEAD")
+  # Add the git hash
   execute_process(
     COMMAND "git" "rev-parse" "--short" "HEAD"
     WORKING_DIRECTORY ${SOURCE_DIR}
@@ -17,6 +18,25 @@ if (EXISTS "${SOURCE_DIR}/.git/HEAD")
   else (GIT_RESULT EQUAL 0)
       MESSAGE("Git command git show-ref failed: ${PROJECT_SOURCE_VERSION}")
   endif (GIT_RESULT EQUAL 0)
+
+  # Add the last commit date
+  execute_process(
+    COMMAND "git" "log" "-1" "--format=%cd" "--date=short"
+    WORKING_DIRECTORY ${SOURCE_DIR}
+    RESULT_VARIABLE GIT_DATE_RESULT
+    OUTPUT_VARIABLE PROJECT_COMMIT_DATE
+  )
+  if (GIT_DATE_RESULT EQUAL 0)
+    string(
+      REGEX REPLACE "\n$" ""
+      PROJECT_COMMIT_DATE
+      ${PROJECT_COMMIT_DATE}
+    )
+    set(CRUX_VERSION_FULL "${CRUX_VERSION_FULL}-${PROJECT_COMMIT_DATE}")
+  else (GIT_DATE_RESULT EQUAL 0)
+    MESSAGE("Git command git show-ref failed: ${PROJECT_COMMIT_DATE}")
+  endif (GIT_DATE_RESULT EQUAL 0)
+
 endif (EXISTS "${SOURCE_DIR}/.git/HEAD")
 
 


### PR DESCRIPTION
This PR adds the date of the latest commit date to the version string.

Before this PR:
```
$ crux version
INFO: Beginning version.
====================
Crux version 3.2-7059ffaa
====================
Proteowizard version 3.0.21014
====================
Percolator version 3.05.nightly-91-d13cfaf4-dirty, Build Date Feb  3 2021 16:40:11
Copyright (c) 2006-9 University of Washington. All rights reserved.
Written by Lukas Käll (lukall@u.washington.edu) in the
Department of Genome Sciences at the University of Washington.
====================
Comet version 2019.01 rev. 5
====================
Boost version 1_67
====================
```

After this PR:
```
$ crux version
INFO: Beginning version.
====================
Crux version 3.2-7059ffaa-2021-02-03
====================
Proteowizard version 3.0.21014
====================
Percolator version 3.05.nightly-91-d13cfaf4-dirty, Build Date Feb  3 2021 16:40:11
Copyright (c) 2006-9 University of Washington. All rights reserved.
Written by Lukas Käll (lukall@u.washington.edu) in the
Department of Genome Sciences at the University of Washington.
====================
Comet version 2019.01 rev. 5
====================
Boost version 1_67
====================
```
