### PR TITLE
Suggested fix for the issue #485

### DIFF
--- a/src/util/Params.cpp
+++ b/src/util/Params.cpp
@@ -1527,14 +1527,6 @@ Params::Params() : finalized_(false) {
   InitBoolParam("find-peptides", true,
                 "Validate peptides by finding them in the given FASTA file.",
                 "Only available for spectral-counts.", false);
-  // ***** static mods *****
-  for (char c = 'A'; c <= 'Z'; c++) {
-    double deltaMass = (c != 'C') ? 0 : CYSTEINE_DEFAULT;
-    bool visible = (c != 'B' && c != 'J' && c != 'O' && c != 'U' && c != 'X' && c != 'Z');
-    InitDoubleParam(string(1, c), deltaMass,
-      "Change the mass of all amino acids '" + string(1, c) + "' by the "
-      "given amount.", "", visible);
-  }
   /* psm-convert options */
   InitStringParam("input-format", "auto", "auto|tsv|sqt|pepxml|mzidentml",
     "Legal values are auto, tsv, sqt, pepxml or mzidentml format.",
@@ -2355,9 +2347,6 @@ void Params::Categorize() {
   items.insert("nmod");
   items.insert("nterm-peptide-mods-spec");
   items.insert("nterm-protein-mods-spec");
-  for (char c = 'A'; c <= 'Z'; c++) {
-    items.insert(string(1, c));
-  }
   items.insert("auto-modifications");
   items.insert("fixed_modification");
   items.insert("fixed_modification_protC");
@@ -3138,13 +3127,7 @@ void Params::FinalizeParams() {
     return;
   }
 
-  for (char c = 'A'; c <= 'Z'; c++) {
-    string aa = string(1, c);
-    double deltaMass = GetDouble(aa);
-    if (deltaMass != 0) {
-      ModificationDefinition::NewStaticMod(aa, deltaMass, ANY);
-    }
-  }
+
 
   if (GetString("enzyme") == "no-enzyme") {
     Set("digestion", "non-specific-digest");


### PR DESCRIPTION
Removing these parameters causes assign-confidence tests to fail because it takes default cysteine mod from this parameter. After its removal assign-confidence outputs peptide masses without the mod which is different from the expected output.
Not sure what would be the right move in this case, input is welcome.