### PR TITLE
Add C++ code linting checks using cpplint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Check release notes
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check that release notes have been updated
+        shell: bash
+        run: |
+          content=$(git diff origin/master -- doc/user/release-notes.html)
+          if [[ ! $content ]]; then
+              echo "Please update the release notes (doc/user/release-notes.html)."
+              exit 1
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Check release notes
+name: Lint and Check Release Notes
 
 on: [push, pull_request]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install cpplint
+
       - name: Check that release notes have been updated
         shell: bash
         run: |
@@ -19,3 +29,8 @@ jobs:
               echo "Please update the release notes (doc/user/release-notes.html)."
               exit 1
           fi
+
+      - name: Lint the proposed changes using cpplint
+        shell: bash
+        run: |
+          cd test/lint && python lint.py -l -d

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Lint the proposed changes using cpplint
         shell: bash
         run: |
-          cd test/lint && python lint.py -l -d
+          cd test/lint && python lint.py -d

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Check release notes
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -92,6 +92,10 @@
 
 <ul>
   <li>
+    March 30, 2021: Added a code linting check with cpplint to verify good
+    code format in every pull request.
+  </li>
+  <li>
     March 24, 2021: Added a check to verify that these release notes are
     updated in every pull request.
   </li>

--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -92,6 +92,10 @@
 
 <ul>
   <li>
+    March 24, 2021: Added a check to verify that these release notes are
+    updated in every pull request.
+  </li>
+  <li>
     Feb 9, 2021: Added process ID number to the names of temporary
     files created by Tide, to avoid conflicts.</li>
   <li>

--- a/src/app/KojakApplication.h
+++ b/src/app/KojakApplication.h
@@ -54,7 +54,8 @@ public:
   virtual COMMAND_T getCommand() const;
 
   /**
-  * \returns whether the application needs the output directory or not. (default false).
+  * \returns whether the application needs the output directory or not.
+  * (default false).
   */
   virtual bool needsOutputDirectory() const;
 

--- a/src/app/KojakApplication.h
+++ b/src/app/KojakApplication.h
@@ -14,67 +14,66 @@
 #include <iostream>
 
 class KojakApplication: public CruxApplication {
-public:
+  public:
 
-  /**
-  * \Default constructor
-  */
-  KojakApplication();
+    /**
+     * \Default constructor
+     */
+    KojakApplication();
 
-  /**
-  * \Default destructor
-  */
-  ~KojakApplication();
+    /**
+     * \Default destructor
+     */
+    ~KojakApplication();
 
-  /**
-  * \returns the command name for KojakApplication
-  */
-  virtual std::string getName() const;
+    /**
+     * \returns the command name for KojakApplication
+     */
+    virtual std::string getName() const;
 
-  /**
-  * \returns the description for KojakApplication
-  */
-  virtual std::string getDescription() const;
+    /**
+     * \returns the description for KojakApplication
+     */
+    virtual std::string getDescription() const;
 
-  /**
-  * \returns the command arguments
-  */
-  virtual std::vector<std::string> getArgs() const;
+    /**
+     * \returns the command arguments
+     */
+    virtual std::vector<std::string> getArgs() const;
 
-  /**
-  * \returns the command options
-  */
-  virtual std::vector<std::string> getOptions() const;
+    /**
+     * \returns the command options
+     */
+    virtual std::vector<std::string> getOptions() const;
 
-  /**
-  * \returns the command outputs
-  */
-  virtual std::vector< std::pair<std::string, std::string> > getOutputs() const;
+    /**
+     * \returns the command outputs
+     */
+    virtual std::vector< std::pair<std::string, std::string> > getOutputs() const;
 
-  virtual COMMAND_T getCommand() const;
+    virtual COMMAND_T getCommand() const;
 
-  /**
-  * \returns whether the application needs the output directory or not.
-  * (default false).
-  */
-  virtual bool needsOutputDirectory() const;
+    /**
+     * \returns whether the application needs the output directory or not.
+     * (default false).
+     */
+    virtual bool needsOutputDirectory() const;
 
-  /**
-   * Run param-medic and sets the parameters accordingly.
-   */
-  virtual void processParams();
+    /**
+     * Run param-medic and sets the parameters accordingly.
+     */
+    virtual void processParams();
 
-  /**
-  * \brief runs kojak on the input spectra
-  * \returns whether kojak was successful or not
-  */
-  virtual int main(int argc, char** argv);
-  int main(const std::vector<std::string>& input_files);
+    /**
+     * \brief runs kojak on the input spectra
+     * \returns whether kojak was successful or not
+     */
+    virtual int main(int argc, char** argv);
+    int main(const std::vector<std::string>& input_files);
 
-protected:
-  KojakManager searchManager_;
+  protected:
+    KojakManager searchManager_;
 };
-
 
 #endif
 

--- a/src/app/KojakApplication.h
+++ b/src/app/KojakApplication.h
@@ -14,65 +14,65 @@
 #include <iostream>
 
 class KojakApplication: public CruxApplication {
-  public:
+ public:
 
-    /**
-     * \Default constructor
-     */
-    KojakApplication();
+  /**
+   * \Default constructor
+   */
+  KojakApplication();
 
-    /**
-     * \Default destructor
-     */
-    ~KojakApplication();
+  /**
+   * \Default destructor
+   */
+  ~KojakApplication();
 
-    /**
-     * \returns the command name for KojakApplication
-     */
-    virtual std::string getName() const;
+  /**
+   * \returns the command name for KojakApplication
+   */
+  virtual std::string getName() const;
 
-    /**
-     * \returns the description for KojakApplication
-     */
-    virtual std::string getDescription() const;
+  /**
+   * \returns the description for KojakApplication
+   */
+  virtual std::string getDescription() const;
 
-    /**
-     * \returns the command arguments
-     */
-    virtual std::vector<std::string> getArgs() const;
+  /**
+   * \returns the command arguments
+   */
+  virtual std::vector<std::string> getArgs() const;
 
-    /**
-     * \returns the command options
-     */
-    virtual std::vector<std::string> getOptions() const;
+  /**
+   * \returns the command options
+   */
+  virtual std::vector<std::string> getOptions() const;
 
-    /**
-     * \returns the command outputs
-     */
-    virtual std::vector< std::pair<std::string, std::string> > getOutputs() const;
+  /**
+   * \returns the command outputs
+   */
+  virtual std::vector< std::pair<std::string, std::string> > getOutputs() const;
 
-    virtual COMMAND_T getCommand() const;
+  virtual COMMAND_T getCommand() const;
 
-    /**
-     * \returns whether the application needs the output directory or not.
-     * (default false).
-     */
-    virtual bool needsOutputDirectory() const;
+  /**
+   * \returns whether the application needs the output directory or not.
+   * (default false).
+   */
+  virtual bool needsOutputDirectory() const;
 
-    /**
-     * Run param-medic and sets the parameters accordingly.
-     */
-    virtual void processParams();
+  /**
+   * Run param-medic and sets the parameters accordingly.
+   */
+  virtual void processParams();
 
-    /**
-     * \brief runs kojak on the input spectra
-     * \returns whether kojak was successful or not
-     */
-    virtual int main(int argc, char** argv);
-    int main(const std::vector<std::string>& input_files);
+  /**
+   * \brief runs kojak on the input spectra
+   * \returns whether kojak was successful or not
+   */
+  virtual int main(int argc, char** argv);
+  int main(const std::vector<std::string>& input_files);
 
-  protected:
-    KojakManager searchManager_;
+ protected:
+  KojakManager searchManager_;
 };
 
 #endif

--- a/test/lint/lint.py
+++ b/test/lint/lint.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Lint the C++ files under the src/app directory"""
+"""Lint the C++ files under the src/app directory
+
+Note that to run this script, you'll need the following dependencies:
+  - Python 3.6+
+  - git
+  - cpplint (Install with 'pip install cpplint')
+"""
 import os
 import sys
 import logging

--- a/test/lint/lint.py
+++ b/test/lint/lint.py
@@ -202,9 +202,9 @@ def main():
 
     # Parse the linting rules:
     rules = [
-        parse_rules(Path(args.exclude), False),
         parse_rules(Path(args.include), True),
         parse_rules(Path(args.lenient_include), (not args.lenient)),
+        parse_rules(Path(args.exclude), False),
     ]
     rules = ",".join(rules)
 
@@ -225,7 +225,7 @@ def main():
         sys.exit(0)
 
     # Run cpplint
-    cpplint(cpp_files)
+    cpplint(cpp_files, filters=rules)
     LOGGER.info("Great job! Linting was completed successfully :D")
 
 

--- a/test/lint/lint.py
+++ b/test/lint/lint.py
@@ -166,7 +166,7 @@ def find_cpp_files(diff_files=None):
     cpp_files = []
     for diff_file in diff_files:
         is_cpp = diff_file.name.lower().endswith(cpp_exts)
-        in_src = src in diff_file.parents
+        in_src = src in diff_file.resolve().parents
         if is_cpp and in_src:
             cpp_files.append(diff_file)
 

--- a/test/lint/lint.py
+++ b/test/lint/lint.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Lint the C++ files under the src/app directory"""
+import os
+import sys
+import logging
+import subprocess
+from pathlib import Path
+from argparse import ArgumentParser
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_args():
+    """Create the parser and command line arguments.
+
+    This is where you should add additionaly options, should they be needed.
+
+    Returns
+    -------
+    ArguementParser
+        The parsed command line arguments.
+    """
+    desc = "Lint the C++ source code of the crux mass spectrometry toolkit."
+    parser = ArgumentParser(description=desc)
+    parser.add_argument(
+        "-d",
+        "--diff-only",
+        default=False,
+        action="store_true",
+        help=(
+            "Lint only modified C++ files as found by performing a "
+            "'git diff' against 'origin/master'."
+        )
+    )
+
+    parser.add_argument(
+        "-l",
+        "--lenient",
+        default=False,
+        action="store_true",
+        help=(
+            "Enable lenient linting. This excludes rules from"
+            "'--lenient-include'"
+        )
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude",
+        default="exclude_rules.txt",
+        type=str,
+        help="A file indicating cpplint rules to exclude, one per line."
+    )
+
+    parser.add_argument(
+        "-i",
+        "--include",
+        default="include_lax_rules.txt",
+        type=str,
+        help="A file indicating cpplint rules to always include, one per line."
+    )
+
+    parser.add_argument(
+        "-n",
+        "--lenient-include",
+        default="include_rules.txt",
+        type=str,
+        help=(
+            "A file indicating cpplint rules to include, one per line. "
+            "These rules are excluded when '--lenient' is used."
+        )
+    )
+
+    return parser.parse_args()
+
+
+def parse_rules(rule_file, include):
+    """Parse the cpplint rules from a rule file.
+
+    Parameters
+    ----------
+    rule_file : Path
+        The file containing cpplint rules, one per line.
+    include : bool
+        Should the rules be included during linting?
+
+    Returns
+    -------
+    str
+        The parsed rules as a single string in a list.
+    """
+    prefix = {True: "+", False: "-"}
+
+    with rule_file.open() as rule_ref:
+        rules = rule_ref.read().splitlines()
+
+    return ",".join([prefix[include] + r for r in rules])
+
+
+def setwd_to_git_root():
+    """Set the working directory to the root of the git project
+
+    Using this makes this script modular---it should work from anywhere
+    within the project.
+
+    Returns
+    -------
+    Path
+        The path of the project root.
+    """
+    cmd = ["git", "rev-parse", "--show-toplevel"]
+    root = subprocess.run(cmd, capture_output=True, check=True).stdout.decode()
+    root = Path(root.rstrip()).resolve()
+    os.chdir(str(root))
+    return root
+
+
+def git_diff():
+    """Perform a git diff against origin/master
+
+    Returns
+    -------
+    List of Paths
+        A list of the changed C++ files as Path objects.
+    """
+    cmd = ["git", "diff", "origin/master", "--name-only"]
+    res = subprocess.run(cmd, capture_output=True, check=True).stdout.decode()
+    diff_files = [Path(f) for f in sorted(res.splitlines())]
+    return diff_files
+
+
+def find_cpp_files(diff_files=None):
+    """Find C++ files that are in the src directory
+
+    Parameters
+    ----------
+    diff_files : List of Paths
+        List of potential C++ files to filter. If None, this function will
+        merely return a single path to the src directory.
+
+    Returns
+    -------
+    List of Paths
+        C++ files in the src directory to lint.
+    """
+    src = Path("src/app").resolve()
+    if diff_files is None:
+        return [src]
+
+    # Tuple of extensions associated with C++ code.
+    # Change this if you don't want to consider certain file types.
+    cpp_exts = (
+        ".c",
+        ".c++",
+        ".cc",
+        ".cpp",
+        ".cu",
+        ".cuh",
+        ".cxx",
+        ".h",
+        ".h++",
+        ".hh",
+        ".hpp",
+        ".hxx",
+    )
+
+    cpp_files = []
+    for diff_file in diff_files:
+        is_cpp = diff_file.name.lower().endswith(cpp_exts)
+        in_src = src in diff_file.parents
+        if is_cpp and in_src:
+            cpp_files.append(diff_file)
+
+    return cpp_files
+
+
+def cpplint(cpp_files, filters=None):
+    """Run cpplint on the specified files
+
+    Parameters
+    ----------
+    cpp_files: list of Paths
+        The C++ files to lint.
+    filters: str
+        The rules to include and exclude for linting.
+    """
+    cmd = ["cpplint", "--recursive"]
+    if filters is not None:
+        cmd.append(f"--filter={filters}")
+
+    subprocess.run(cmd + list(cpp_files), check=True, text=True)
+
+
+def main():
+    """The main function"""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s: %(message)s"
+    )
+
+    # Parse command line arguments:
+    args = get_args()
+
+    # Parse the linting rules:
+    rules = [
+        parse_rules(Path(args.exclude), False),
+        parse_rules(Path(args.include), True),
+        parse_rules(Path(args.lenient_include), (not args.lenient)),
+    ]
+    rules = ",".join(rules)
+
+    # Move to the project root:
+    setwd_to_git_root()
+
+    # Get the modified files:
+    if args.diff_only:
+        cpp_files = find_cpp_files(git_diff())
+        LOGGER.info("Linting %i modified C++ files...", len(cpp_files))
+    else:
+        cpp_files = find_cpp_files()
+        LOGGER.info("Linting all C++ files in src tree...")
+
+    # If no files are modified and modified_files is not None:
+    if not cpp_files:
+        LOGGER.info("There was nothing to lint with this change.")
+        sys.exit(0)
+
+    # Run cpplint
+    cpplint(cpp_files)
+    LOGGER.info("Great job! Linting was completed successfully :D")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR add code linting checks through [cpplint](https://github.com/cpplint/cpplint) that are run with every push and pull request. Specifically, these checks will lint only C++ files under `src/app` that have been modified with the proposed changes. The idea is that as different parts of the code base are modified, our code standards are enforced consistently. Over time, this should gradually improve the adherence of our code to the our standards throughout the project.

Unfortunately, this means that the entirety of a modified file will be linted and the check will fail---even if the violations occur outside of the code that was modified or added. However, we can look at this as an opportunity to improve our code formatting during the PR revision process. 