### PR TITLE
Fixed  issue with wrong .observed  files being created  when smoke tests are run.

### DIFF
--- a/test/smoke-tests/features/support/CruxTester.rb
+++ b/test/smoke-tests/features/support/CruxTester.rb
@@ -98,7 +98,7 @@ class CruxTester
     compRes = system("python", "./features/support/fileComparator.py", "-r", precision, expected, actual)
 
     if compRes == false
-      file_content = File.read(expected)
+      file_content = File.read(actual)
       writeObserved(file_content, expected, false, 1)
     end
 
@@ -109,7 +109,7 @@ class CruxTester
     compRes = system("python", "./features/support/fileComparator.py", "-u", "-r", precision, expected, actual)
 
     if compRes == false
-      file_content = File.read(expected)
+      file_content = File.read(actual)
       writeObserved(file_content, expected, false, 1)
     end
 


### PR DESCRIPTION
# Description

Currently when smoke tests are run the .observed files generated are identical to the actual files. This makes it hard to detect issues raised by the fileComparator.py

Fixes [issue #551](https://github.com/crux-toolkit/crux-toolkit/issues/551)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Smoke tests were run and the .observed files were compared with the actual files using total commander.

- [x] Smoke Tests

**Test Configuration**:
* Operating System:  Ubuntu 18.04.6 LTS
