### PR TITLE
Xcorr scoring cpp

### DIFF
--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -56,8 +56,7 @@
 
 <h4>Minor changes</h4>
 <ul>
-  <li>01 Apr 2022: XCorr scoring implemented in C++, temporarily solved bug in threading issue: https://github.com/crux-toolkit/crux-toolkit/issues/407 
-  <li>01 Apr 2022: Fixed bugs in the speed tide update. Updated smoke-tests, timing tests. </li> 
+  <li>01 May 2022: XCorr scoring implementing in C++. This resolves a longstanding bug in our multithreading code. 
   <li>20 Jan 2022: The XCorr scoring, exact p-value, and ResEv in Tide-Search has been sped up. </li> 
   <li>10 Jan 2022: Fixed bug that resulted in rank=0 for search results in pepxml files (issue #521).</li>                       
   <li>16 Nov 2021: The preprocessing of the exact p-value method has been aligned to the preprocessing of the standard XCorr scoring. </li> 

--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -56,6 +56,8 @@
 
 <h4>Minor changes</h4>
 <ul>
+  <li>01 Apr 2022: XCorr scoring implemented in C++, temporarily solved bug in threading issue: https://github.com/crux-toolkit/crux-toolkit/issues/407 
+  <li>01 Apr 2022: Fixed bugs in the speed tide update. Updated smoke-tests, timing tests. </li> 
   <li>20 Jan 2022: The XCorr scoring, exact p-value, and ResEv in Tide-Search has been sped up. </li> 
   <li>10 Jan 2022: Fixed bug that resulted in rank=0 for search results in pepxml files (issue #521).</li>                       
   <li>16 Nov 2021: The preprocessing of the exact p-value method has been aligned to the preprocessing of the standard XCorr scoring. </li> 

--- a/src/app/TideSearchApplication.cpp
+++ b/src/app/TideSearchApplication.cpp
@@ -1648,7 +1648,6 @@ vector<string> TideSearchApplication::getOptions() const {
     "fileroot",
     "isotope-error",
     "mass-precision",
-//    "min-precursor-charge",
     "max-precursor-charge",
     "min-peaks",
     "mod-precision",

--- a/src/app/TideSearchApplication.cpp
+++ b/src/app/TideSearchApplication.cpp
@@ -38,6 +38,14 @@ const double TideSearchApplication::XCORR_SCALING = 100000000.0;
  * tide/spectrum_preprocess2.cc). */
 const double TideSearchApplication::RESCALE_FACTOR = 20.0;
 
+/* There is a macro defined in ./tide/theoretical_peak_set.h and called CPP_SCORING
+ * which controls  whether the XCorr scoring should be executed by the original assembly code  
+ * defined in collectScoresCompiled implemented by Benjamin, or it should be executed by a plain C++ code. 
+ * The macro appears in active_peptide_queue.cc and peptide.cc. The code in  
+ * assembly is faster albeit is segfaults in multi-threading. See: 
+ * https://github.com/crux-toolkit/crux-toolkit/issues/407
+ */
+
 TideSearchApplication::TideSearchApplication():
   exact_pval_search_(false), remove_index_(""), spectrum_flag_(NULL) {
 }
@@ -630,13 +638,45 @@ void TideSearchApplication::search(void* threadarg) {
 
       int candidatePeptideStatusSize = candidatePeptideStatus->size();
       TideMatchSet::Arr2 match_arr2(candidatePeptideStatusSize); // Scored peptides will go here.
-
-      // Programs for taking the dot-product with the observed spectrum are laid
-      // out in memory managed by the active_peptide_queue, one program for each
-      // candidate peptide. The programs will store the results directly into
-      // match_arr. We now pass control to those programs.
-      collectScoresCompiled(active_peptide_queue, spectrum, observed, &match_arr2,
-                            candidatePeptideStatusSize, charge);
+  
+#ifdef CPP_SCORING
+      //Scoring in C++		
+        deque<Peptide*>::const_iterator iter_ = active_peptide_queue->iter_;
+        TideMatchSet::Arr2::iterator it = match_arr2.begin();
+        const int* cache = observed.GetCache();        
+        int cnt = 0;
+        for (; iter_ != active_peptide_queue->end_; ++iter_, ++it, ++cnt) {
+          unsigned int xcorr = 0;
+		  
+		  // Score with single charged theoretical peaks
+          for (vector<unsigned int>::const_iterator iter_uint = (*iter_)->peaks_0.begin();
+            iter_uint != (*iter_)->peaks_0.end();
+            iter_uint++) {
+              xcorr += cache[*iter_uint];
+            }
+		  // Score with double charged theoretical peaks
+          if (charge > 2){
+            for (vector<unsigned int>::const_iterator iter_uint = (*iter_)->peaks_1.begin();
+              iter_uint != (*iter_)->peaks_1.end();
+              iter_uint++) {
+                xcorr += cache[*iter_uint];
+              }
+          }
+          
+          it->first = xcorr;
+          it->second = candidatePeptideStatusSize - cnt;
+        } 
+        match_arr2.set_size(candidatePeptideStatusSize);
+        // End Scoring in C++
+#else
+        // Programs for taking the dot-product with the observed spectrum are laid
+        // out in memory managed by the active_peptide_queue, one program for each
+        // candidate peptide. The programs will store the results directly into
+        // match_arr. We now pass control to those programs.
+	
+        collectScoresCompiled(active_peptide_queue, spectrum, observed, &match_arr2,
+                              candidatePeptideStatusSize, charge);
+#endif
 
       // matches will arrange the results in a heap by score, return the top
       // few, and recover the association between counter and peptide. We output
@@ -655,7 +695,6 @@ void TideSearchApplication::search(void* threadarg) {
         double quantile_score = 1.0;
         if (Params::GetBool("use-tailor-calibration")) {
           vector<double> scores;
-          double quantile_th = TAILOR_QUANTILE_TH;
           // Collect the scores for the score tail distribution
           for (TideMatchSet::Arr2::iterator it = match_arr2.begin();
             it != match_arr2.end();
@@ -663,16 +702,16 @@ void TideSearchApplication::search(void* threadarg) {
             scores.push_back((double)(it->first / XCORR_SCALING));
           }
           sort(scores.begin(), scores.end(), greater<double>());  //sort in decreasing order
-          int quantile_pos = (int)(quantile_th*(double)scores.size()+0.5);
+          int quantile_pos = (int)(TAILOR_QUANTILE_TH*(double)scores.size()+0.5);
 
           if (quantile_pos < 3) quantile_pos = 3;
 
-          // suggested by Attila for bug fix
           if (quantile_pos >= scores.size()) { quantile_pos = scores.size()-1; }
 
           quantile_score = scores[quantile_pos]+TAILOR_OFFSET; // Make sure scores positive
         }  //End of Tailor
         TideMatchSet::Arr match_arr(nCandPeptide);
+
         for (TideMatchSet::Arr2::iterator it = match_arr2.begin();
              it != match_arr2.end();
              ++it) {
@@ -690,12 +729,14 @@ void TideSearchApplication::search(void* threadarg) {
         }
 
         TideMatchSet matches(&match_arr, highest_mz);
+
         matches.exact_pval_search_ = exact_pval_search;
         matches.cur_score_function_ = curScoreFunction;
 
         matches.report(target_file, decoy_file, top_matches, numDecoys, spectrum_filename,
                        spectrum, charge, active_peptide_queue, proteins,
                        locations, compute_sp, true, locks_array[LOCK_RESULTS]);
+					   
       }  //end peptide_centric == false
     } else { //This runs curScoreFunction=BOTH_SCORE, curScoreFunction=RESIUDUE_EVIDENCE_MATRIX, and xcorr p-val
 
@@ -1605,6 +1646,7 @@ vector<string> TideSearchApplication::getOptions() const {
     "fileroot",
     "isotope-error",
     "mass-precision",
+//    "min-precursor-charge",
     "max-precursor-charge",
     "min-peaks",
     "mod-precision",

--- a/src/app/tide/peptide.cc
+++ b/src/app/tide/peptide.cc
@@ -172,6 +172,8 @@ void Peptide::Compile(const TheoreticalPeakArr* peaks,
 #ifdef CPP_SCORING
   // Store the theoretical peak indeces for the peptide in a vector. 
   int i;
+  peaks_0.clear();
+  peaks_1.clear();
   peaks_0.reserve(peaks[0].size());
   peaks_1.reserve(peaks[1].size());
   

--- a/src/app/tide/peptide.cc
+++ b/src/app/tide/peptide.cc
@@ -169,6 +169,21 @@ void Peptide::Compile(const TheoreticalPeakArr* peaks,
                       const pb::Peptide& pb_peptide,
                       TheoreticalPeakCompiler* compiler_prog1,
                       TheoreticalPeakCompiler* compiler_prog2) {
+#ifdef CPP_SCORING
+  // Store the theoretical peak indeces for the peptide in a vector. 
+  int i;
+  peaks_0.reserve(peaks[0].size());
+  peaks_1.reserve(peaks[1].size());
+  
+  for (i = 0; i < peaks[0].size(); ++i) {
+    peaks_0.push_back(peaks[0][i]);
+  }
+  for (i = 0; i < peaks[1].size(); ++i) {
+    peaks_1.push_back(peaks[1][i]);
+  }
+  prog1_ = (void*)3;  //Mark the peptide that it contains theoretical peaks to score
+#else
+  // Create the Assembly code for scoring. 
   int pos_size = peaks[0].size();
   prog1_ = compiler_prog1->Init(pos_size, 0);
   compiler_prog1->AddPositive(peaks[0]);
@@ -179,6 +194,7 @@ void Peptide::Compile(const TheoreticalPeakArr* peaks,
   compiler_prog2->AddPositive(peaks[0]);
   compiler_prog2->AddPositive(peaks[1]);
   compiler_prog2->Done();
+#endif
 }
 
 void Peptide::ComputeTheoreticalPeaks(TheoreticalPeakSetBYSparse* workspace, bool dia_mode) {

--- a/src/app/tide/peptide.h
+++ b/src/app/tide/peptide.h
@@ -257,7 +257,6 @@ class Peptide {
 
   void* prog1_;
   void* prog2_;
-  
 
   // added by Yang
   vector<int> ion_mzbins_, b_ion_mzbins_, y_ion_mzbins_;

--- a/src/app/tide/peptide.h
+++ b/src/app/tide/peptide.h
@@ -225,7 +225,10 @@ class Peptide {
   vector<int>& BIonMzbins() { return b_ion_mzbins_; }
   vector<int>& YIonMzbins() { return y_ion_mzbins_; }
   vector<double>& IonMzs() { return ion_mzs_; } // added for debug purpose
-
+  
+  vector<unsigned int> peaks_0;
+  vector<unsigned int> peaks_1;
+  
 
  private:
   template<class W> void AddIons(W* workspace, bool dia_mode = false) ;
@@ -254,6 +257,7 @@ class Peptide {
 
   void* prog1_;
   void* prog2_;
+  
 
   // added by Yang
   vector<int> ion_mzbins_, b_ion_mzbins_, y_ion_mzbins_;

--- a/src/app/tide/theoretical_peak_set.h
+++ b/src/app/tide/theoretical_peak_set.h
@@ -39,6 +39,10 @@
 #include <functional>
 #include "fixed_cap_array.h"
 
+// Macro to switch between xcorr scoring implemented in Assembly or C++
+// This macro appears in TideSearchApplication.cpp, peptide.cc, and active_peptide_queue.cc
+#define CPP_SCORING 1
+
 using namespace std;
 typedef google::protobuf::RepeatedField<int>::const_iterator FieldIter;
 

--- a/test/smoke-tests/features/support/CruxTester.rb
+++ b/test/smoke-tests/features/support/CruxTester.rb
@@ -98,10 +98,11 @@ class CruxTester
     compRes = system("python", "./features/support/fileComparator.py", "-r", precision, expected, actual)
 
     if compRes == false
-      file_content = File.read(actual)
+      file_content = File.read(actual)       # Use this to keep original target results and report the actual output.
+      # file_content = File.read(expected)   # Use this to overwrite the original target results with the current results. Update the smoke-test.
       writeObserved(file_content, expected, false, 1)
     end
-
+    
     return compRes
   end
 
@@ -109,7 +110,8 @@ class CruxTester
     compRes = system("python", "./features/support/fileComparator.py", "-u", "-r", precision, expected, actual)
 
     if compRes == false
-      file_content = File.read(actual)
+      file_content = File.read(actual)       # Use this line to keep original target results, and report the actua output. 
+      # file_content = File.read(expected)   # Use this line to overwrite the original target results with the current results. Update the smoke-test
       writeObserved(file_content, expected, false, 1)
     end
 


### PR DESCRIPTION
Contains code to perform the XCorr scoring in C++. This temporarily solves the threading segfault issue:  https://github.com/crux-toolkit/crux-toolkit/issues/407  It produces exactly the same Xcorrs as the original XCorr scoring method implemented in assembly. All performance tests and smoke tests pass. This also should compile on ARM processors. 