### PR TITLE
added the min_peptide_score parameter to kojak

### DIFF
--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -56,6 +56,7 @@
 
 <h4>Minor changes</h4>
 <ul>
+  <li>19 July 2022: Added min_peptide_score parameter to Kojak. </li>
   <li>09 June 2022: Upgraded to ProteoWizard 3.0.22014 (commit aadd392). This
   also upgrades to BOOST 1.67 which fixes a problem building Crux on current MacOS
   systems.</li>

--- a/src/app/KojakApplication.cpp
+++ b/src/app/KojakApplication.cpp
@@ -61,6 +61,8 @@ int KojakApplication::main(const vector<string>& input_files) {
   str_params.push_back("e_value_depth");
   str_params.push_back("truncate_prot_names");
   str_params.push_back("fragment_bin_offset");
+  str_params.push_back("min_peptide_score");
+  
 
   // Vector for boolean parameters, which must be converted to 0/1 strings
   std::vector<std::string> bool_params;
@@ -283,6 +285,7 @@ vector<string> KojakApplication::getOptions() const {
    "max_miscleavages",
    "max_peptide_mass",
    "min_peptide_mass",
+   "min_peptide_score",
    "min_spectrum_peaks",
    "max_spectrum_peaks",
    "ppm_tolerance_pre",

--- a/src/util/Params.cpp
+++ b/src/util/Params.cpp
@@ -2052,6 +2052,10 @@ Params::Params() : finalized_(false) {
     "spectrum. However, larger numbers also increase computation time. The "
     "recommended values are between 2000 and 10000",
     "Available for kojak", true);
+  InitDoubleParam("min_peptide_score", 0.0, -10.0, 10.0,
+    "Minimum peptide score used for Kojak analysis ",
+    "Available for kojak", true);
+    
 
   InitBoolParam("no-analytics", false, "Don't post data to Google Analytics.", "", false);
 

--- a/src/util/Params.cpp
+++ b/src/util/Params.cpp
@@ -2052,10 +2052,13 @@ Params::Params() : finalized_(false) {
     "spectrum. However, larger numbers also increase computation time. The "
     "recommended values are between 2000 and 10000",
     "Available for kojak", true);
-  InitDoubleParam("min_peptide_score", 0.0, -10.0, 10.0,
-    "Minimum peptide score used for Kojak analysis ",
+  InitDoubleParam("min_peptide_score", 0.1, -10.0, 10.0,
+    "The minimum peptide score threshold for the first (alpha) peptide during "
+    "crosslink analysis. During the first pass in the analysis, if the top "
+    "scoring alpha peptides do not exceed this threshold, they will not be "
+    "considered for pairing with a second (beta) peptide during the second "
+    "pass of the analysis. ",
     "Available for kojak", true);
-    
 
   InitBoolParam("no-analytics", false, "Don't post data to Google Analytics.", "", false);
 

--- a/test/smoke-tests/good_results/psmconv-from-txt1.pep.xml
+++ b/test/smoke-tests/good_results/psmconv-from-txt1.pep.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href=""?>
-<msms_pipeline_analysis date="2022-03-14T12:03:01" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://regis-web.systemsbiology.net/pepXML /usr/local/tpp/schema/pepXML_v110.xsd" summary_xml="">
+<msms_pipeline_analysis date="2022-07-19T10:05:49" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://regis-web.systemsbiology.net/pepXML /usr/local/tpp/schema/pepXML_v110.xsd" summary_xml="">
 <msms_run_summary base_name="NA" msManufacturer="NA" msModel="NA" msIonization="NA" raw_data_type="NA" raw_data="NA" >
 <sample_enzyme name="trypsin">
 </sample_enzyme>
@@ -410,6 +410,7 @@
 <parameter name="top_count" value="20"/>
 <parameter name="truncate_prot_names" value="0"/>
 <parameter name="e_value_depth" value="5000"/>
+<parameter name="min_peptide_score" value="0.1"/>
 <parameter name="predrt-files" value=""/>
 <parameter name="msamanda-regional-topk" value="10"/>
 <parameter name="coelution-oneside-scans" value="3"/>

--- a/test/smoke-tests/good_results/psmconv-from-txt2.pep.xml
+++ b/test/smoke-tests/good_results/psmconv-from-txt2.pep.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href=""?>
-<msms_pipeline_analysis date="2022-03-14T12:03:01" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://regis-web.systemsbiology.net/pepXML /usr/local/tpp/schema/pepXML_v110.xsd" summary_xml="">
+<msms_pipeline_analysis date="2022-07-19T10:05:49" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://regis-web.systemsbiology.net/pepXML /usr/local/tpp/schema/pepXML_v110.xsd" summary_xml="">
 <msms_run_summary base_name="NA" msManufacturer="NA" msModel="NA" msIonization="NA" raw_data_type="NA" raw_data="NA" >
 <sample_enzyme name="trypsin">
 </sample_enzyme>
@@ -387,6 +387,7 @@
 <parameter name="top_count" value="20"/>
 <parameter name="truncate_prot_names" value="0"/>
 <parameter name="e_value_depth" value="5000"/>
+<parameter name="min_peptide_score" value="0.1"/>
 <parameter name="predrt-files" value=""/>
 <parameter name="msamanda-regional-topk" value="10"/>
 <parameter name="coelution-oneside-scans" value="3"/>


### PR DESCRIPTION
The new parameter is “min_peptide_score = #.#”. By default (i.e. if the parameter is not specified), the value is zero. This parameter is currently in the Kojak that ships with Crux, although at the time it was undocumented for testing. Over the past several months, I’ve found it valuable to set it between 0.2 and 0.5 for most datasets. I’m making it a documented parameter for all users later today.  -- MH

The range of this parameter is -10 .0till +10.0

I do not know how to use Kojak so the functionality of the parameter and that its value is passed to Kojak properly should be tested.

