### PR TITLE
Percolator fix

### DIFF
--- a/src/app/PercolatorAdapter.cpp
+++ b/src/app/PercolatorAdapter.cpp
@@ -61,6 +61,9 @@ void PercolatorAdapter::deleteCollections() {
  * Adds PSM scores from Percolator objects into a ProteinMatchCollection
  */
 void PercolatorAdapter::processPsmScores(Scores& allScores) {
+  if ( !Params::GetBool("mzid-output") && !Params::GetBool("pepxml-output") ) {
+    return;
+  }
   if (collection_ == NULL || decoy_collection_ == NULL) {
     return;
   }
@@ -176,6 +179,9 @@ void PercolatorAdapter::processPsmScores(Scores& allScores) {
  * Adds peptide scores from Percolator objects into a ProteinMatchCollection
  */
 void PercolatorAdapter::processPeptideScores(Scores& allScores) {
+  if ( !Params::GetBool("mzid-output") && !Params::GetBool("pepxml-output") ) {
+    return;
+  }
   if (collection_ == NULL || decoy_collection_ == NULL) {
     return;
   }
@@ -211,6 +217,9 @@ void PercolatorAdapter::processPeptideScores(Scores& allScores) {
  * Adds protein scores from Percolator objects into a ProteinMatchCollection
  */
 void PercolatorAdapter::processProteinScores(ProteinProbEstimator* protEstimator) {
+  if ( !Params::GetBool("mzid-output") && !Params::GetBool("pepxml-output") ) {
+    return;
+  }
   if (collection_ == NULL || decoy_collection_ == NULL) {
     return;
   }


### PR DESCRIPTION
This is a fix to [issue 582](https://github.com/crux-toolkit/crux-toolkit/issues/582).

The basic problem is that Crux's PSM parsing code can't parse PSMs from Kojak, since they contain cross-linked peptides, which Crux knows nothing about. However, the key insight is that if the user doesn't ask for pepxml or mzid output, then there is no reason for Crux to parse those PSMs in the first place. I therefore refactored the code a bit so that it would check whether either of those two output formats was requested, by inserting a line like this in various places:

```
 if ( Params::GetBool("mzid-output") || Params::GetBool("pepxml-output") ) {
```

The upshot is that now Percolator will run to completion unless the user asks for one of those two output formats. It still dies ungracefully in that case, but I think that's OK for now. I anticipate that we may simply remove these output formats from Percolator in a future version.

Note that I also fixed a small bug in which the peptide-level output files were being requested even if the user specified the --only-psms option.