### PR TITLE
added an error message when tailor calibration is intented to be used…

### DIFF
--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -56,6 +56,8 @@
 
 <h4>Minor changes</h4>
 <ul>
+  <li>13 Jan 2023: tide-search halts when tailor-calibration is intented to be 
+    used in peptide-centric-search.</li>
   <li>13 Jan 2023: Added a check to verify that these release notes are
     updated in every pull request.</li>
   <li>09 Jan 2023: Upgraded to Comet 2022.01 rev 2. Fixed issue #572: handling of

--- a/src/app/TideSearchApplication.cpp
+++ b/src/app/TideSearchApplication.cpp
@@ -160,6 +160,10 @@ int TideSearchApplication::main(const vector<string>& input_files, const string 
     carp(CARP_FATAL, "--score-function 'residue-evidence' is not implemented "
                     "with Tailor score calibration method");
 
+  if (Params::GetBool("use-tailor-calibration") && Params::GetBool("peptide-centric-search") )
+    carp(CARP_FATAL, "--peptide-centric-search is not implemented "
+                    "with Tailor score calibration method");
+
   // Check compute-sp parameter
   bool compute_sp = Params::GetBool("compute-sp");
   if (Params::GetBool("sqt-output") && !compute_sp) {


### PR DESCRIPTION
… in peptide-centric-search in tide-search. It just throws a carp_fatal error when both tailor-calibration and peptide-centric-search are True in tide-search. 

Smoke tests pass. Release notes are updated. 