### PR TITLE
Fix for Issue 594

### DIFF
--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -54,6 +54,8 @@
 
 <h4>Minor changes</h4>
 <ul>
+  <li>10 July 2023: Added support for the percolator --no-terminate option, which
+  allows execution to continue even if the SVM encounters issues.</li>
   <li>30 May 2023: File overwrite bug fix in diameter</li>
   <li>14 April 2023: Added by-ions matched, by-ions total, and by-ions-fraction columns to tide-search output 
     in case of standard XCorr scoring.</li>

--- a/src/app/PercolatorApplication.cpp
+++ b/src/app/PercolatorApplication.cpp
@@ -266,6 +266,10 @@ int PercolatorApplication::main(
     perc_args_vec.push_back("--static");
   }
 
+  if (Params::GetBool("no-terminate")) {
+    perc_args_vec.push_back("--no-terminate");
+  }
+
   if (!Params::GetString("default-direction").empty()) {  
     perc_args_vec.push_back("--default-direction");
     perc_args_vec.push_back(Params::GetString("default-direction"));
@@ -509,6 +513,7 @@ vector<string> PercolatorApplication::getOptions() const {
     "max-charge-feature",
     "maxiter",
     "mzid-output",
+    "no-terminate",
     "only-psms",
     "output-dir",
     "output-weights",

--- a/src/util/Params.cpp
+++ b/src/util/Params.cpp
@@ -521,6 +521,9 @@ InitStringParam("protein-name-separator", ",",
   InitStringParam("decoy-prefix", "decoy_",
     "Specifies the prefix of the protein names that indicate a decoy.",
     "Available for tide-index and percolator", true);
+  InitBoolParam("no-terminate", false,
+    "Do not stop execution when encountering questionable SVM inputs or results. \"percolator.weights.txt\".",
+    "Available for percolator", true);
   InitBoolParam("output-weights", false,
     "Output final weights to a file named \"percolator.weights.txt\".",
     "Available for percolator", true);

--- a/test/smoke-tests/good_results/psmconv-from-txt1.pep.xml
+++ b/test/smoke-tests/good_results/psmconv-from-txt1.pep.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href=""?>
-<msms_pipeline_analysis date="2022-11-22T12:36:52" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://regis-web.systemsbiology.net/pepXML /usr/local/tpp/schema/pepXML_v110.xsd" summary_xml="">
+<msms_pipeline_analysis date="2023-07-06T21:27:22" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://regis-web.systemsbiology.net/pepXML /usr/local/tpp/schema/pepXML_v110.xsd" summary_xml="">
 <msms_run_summary base_name="NA" msManufacturer="NA" msModel="NA" msIonization="NA" raw_data_type="NA" raw_data="NA" >
 <sample_enzyme name="trypsin">
 </sample_enzyme>
@@ -99,6 +99,7 @@
 <parameter name="feature-file-out" value="false"/>
 <parameter name="decoy-xml-output" value="false"/>
 <parameter name="decoy-prefix" value="decoy_"/>
+<parameter name="no-terminate" value="false"/>
 <parameter name="output-weights" value="false"/>
 <parameter name="init-weights" value=""/>
 <parameter name="static" value="false"/>

--- a/test/smoke-tests/good_results/psmconv-from-txt2.pep.xml
+++ b/test/smoke-tests/good_results/psmconv-from-txt2.pep.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href=""?>
-<msms_pipeline_analysis date="2022-11-22T12:36:52" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://regis-web.systemsbiology.net/pepXML /usr/local/tpp/schema/pepXML_v110.xsd" summary_xml="">
+<msms_pipeline_analysis date="2023-07-06T21:29:48" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://regis-web.systemsbiology.net/pepXML /usr/local/tpp/schema/pepXML_v110.xsd" summary_xml="">
 <msms_run_summary base_name="NA" msManufacturer="NA" msModel="NA" msIonization="NA" raw_data_type="NA" raw_data="NA" >
 <sample_enzyme name="trypsin">
 </sample_enzyme>
@@ -76,6 +76,7 @@
 <parameter name="feature-file-out" value="false"/>
 <parameter name="decoy-xml-output" value="false"/>
 <parameter name="decoy-prefix" value="decoy_"/>
+<parameter name="no-terminate" value="false"/>
 <parameter name="output-weights" value="false"/>
 <parameter name="init-weights" value=""/>
 <parameter name="static" value="false"/>


### PR DESCRIPTION
This commit should close issue 594: missing options for percolator. All but one of the missing percolator options had already been added by Attila and Sean. This should take care of the last one: '--no-terminate'.