### PR TITLE
Added a recipe for building crux-toolkit for conda.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   - url: https://noble.gs.washington.edu/crux-downloads/crux-{{ version }}/crux-{{ version }}.Linux.x86_64.zip  # [linux]
     sha256: b5c1a02416f0220beb6106e12a7b330932dec396291ae364af8f2153a1e1655d  # [linux]
   - url: https://noble.gs.washington.edu/crux-downloads/crux-{{ version }}/crux-{{ version }}.Darwin.x86_64.zip  # [osx]
-    sha256: 9f7b060e67ec250e4c2a10b783eb1777497ec0d1151e5bc9630f67f411b595ac  # [osx]
+    sha256: 5f1fb9124391cec30608740fdce3aea7fcb3f19330531ea90f6ecf81b8583d00  # [osx]
 
 build:
   number: 2

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "4.2" %}
+
+package:
+  name: crux-toolkit
+  version: {{ version }}
+
+source:
+  - url: https://noble.gs.washington.edu/crux-downloads/crux-{{ version }}/crux-{{ version }}.Linux.x86_64.zip  # [linux]
+    sha256: b5c1a02416f0220beb6106e12a7b330932dec396291ae364af8f2153a1e1655d  # [linux]
+  - url: https://noble.gs.washington.edu/crux-downloads/crux-{{ version }}/crux-{{ version }}.Darwin.x86_64.zip  # [osx]
+    sha256: 9f7b060e67ec250e4c2a10b783eb1777497ec0d1151e5bc9630f67f411b595ac  # [osx]
+
+build:
+  number: 2
+  script: "mkdir -p $PREFIX/bin; chmod a+x bin/*; cp bin/* $PREFIX/bin"
+
+requirements:
+  build:
+    # both needed as run-time dependencies
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+
+test:
+  commands:
+    - crux version 2> /dev/null | grep -q 'Crux version'
+
+about:
+  home: http://crux.ms
+  summary: A cross-platform suite of analysis tools for interpreting protein mass spectrometry data
+  license: Apache-2.0
+  license_family: Apache
+  dev_url: https://github.com/crux-toolkit/crux-toolkit
+
+extra:
+  skip-lints:
+    - should_not_be_noarch_source


### PR DESCRIPTION
Owing to [this](https://github.com/crux-toolkit/crux-toolkit/issues/684) discussion, I added the conda recipe for building crux-toolkit for conda. If merged and used, [this](https://anaconda.org/crux-toolkit/crux-toolkit) should become the official crux-toolkit conda package.
The recipe is based on the [bioconda recipe](https://github.com/bioconda/bioconda-recipes/blob/a6e549d84445828a62807dce684c1b4c846001e9/recipes/crux-toolkit/meta.yaml).

Currently, this will be done manually but to automate it we could look into a GitHub Action. Perhaps [this ](https://github.com/marketplace/actions/build-and-upload-conda-packages) GitHub Action could help with that.

NB// When users are installing with conda they need this package-dependency:
https://anaconda.org/conda-forge/libgcc-ng