### PR TITLE
removed few push_backs from loops

### DIFF
--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -71,6 +71,7 @@
   </li>
 <h4>Minor changes</h4>
 <ul>
+  <li>14 Feb 2025: Improved tide-search run time.</li>
   <li>6 Feb 2025: create Spectrum Convert application.</li>
   <li>28 Jan 2025: Bug fix in tide-search when searching without decoy peptides. </li>
   <li>25 Oct 2024: Fixed bug in parameter handling for spectral-counts inside of the pipeline command.</li>

--- a/src/app/DIAmeterApplication.cpp
+++ b/src/app/DIAmeterApplication.cpp
@@ -279,7 +279,7 @@ int DIAmeterApplication::main(const vector<string>& input_files, const string in
             continue; 
           }
           // allocate PSMscores for N scores
-          TideMatchSet psm_scores(active_peptide_queue);  //nPeptides_ includes acitve and inacitve peptides
+          TideMatchSet psm_scores(active_peptide_queue, &observed);  //nPeptides_ includes acitve and inacitve peptides
 
           TideSearchApplication::XCorrScoring(charge, observed, active_peptide_queue, psm_scores);
 
@@ -372,8 +372,8 @@ void DIAmeterApplication::reportDIA(
   // vector<TideMatchSet::Arr::iterator> targets, decoys;
   // matches->gatherTargetsAndDecoys(peptides, proteins, targets, decoys, Params::GetInt("top-match"), 1, true);
   matches.gatherTargetsDecoys();
-  matches.calculateAdditionalScores(matches.concat_or_target_psm_scores_);
-  matches.calculateAdditionalScores(matches.decoy_psm_scores_);
+  matches.calculateAdditionalScores(matches.concat_or_target_psm_scores_, &sc);
+  matches.calculateAdditionalScores(matches.decoy_psm_scores_, &sc);
 
   // calculate precursor intensity logrank (ppm-based)
   int peak_num_new = -1; double *mz_arr_new = NULL, *intensity_arr_new = NULL, *intensity_rank_arr_new = NULL;

--- a/src/app/TideMatchSet.cpp
+++ b/src/app/TideMatchSet.cpp
@@ -392,8 +392,6 @@ void TideMatchSet::gatherTargetsDecoys() {
   }
   quantile_score_ = psm_scores_[psm_scores_.size()-1-quantile_pos].xcorr_score_ + TAILOR_OFFSET; // Make sure scores positive
 
-  // carp(CARP_INFO, "PSM_scores:  %d Quantile pos: %d , qunatile_score: %lf",psm_scores_.size(), quantile_pos, quantile_score_ );
-
   // get the value of the last score for the delta_lcn scores
   last_psm_ = std::min_element(psm_scores_.begin(), psm_scores_.end(), comp);
   
@@ -447,7 +445,6 @@ void TideMatchSet::calculateAdditionalScores(PSMScores& psm_scores, const Spectr
     // Count the repeating matching ions. This was used in SP scoring
     temp = 0;
     repeat_ion_match = 0;
-//    peptide = active_peptide_queue_->GetPeptide((*it).ordinal_);
     peptide = (*((*it).peptide_itr_));
     temp = TideSearchApplication::PeakMatching(*observed_, peptide->peaks_1b, temp, repeat_ion_match);
     temp = TideSearchApplication::PeakMatching(*observed_, peptide->peaks_1y, temp, repeat_ion_match);

--- a/src/app/TideSearchApplication.cpp
+++ b/src/app/TideSearchApplication.cpp
@@ -339,7 +339,6 @@ void TideSearchApplication::spectrum_search(void *threadarg) {
     }
 
     pb_spectrum = spectrum_pair.first;
-    // carp(CARP_INFO, "neutral mass: %lf\t thread id: %d", pb_spectrum.neutral_mass(), thread_id);
     locks_array_[LOCK_SPECTRUM_READING]->unlock();
     
     Spectrum* spectrum = new Spectrum(pb_spectrum); 
@@ -439,7 +438,6 @@ void TideSearchApplication::XCorrScoring(int charge, ObservedPeakSet& observed, 
     iter != active_peptide_queue->end_;
     ++iter, ++cnt) {
     if ((*iter)->active_ == false && score_inactive_peptides == false) 
-//      if (active_peptide_queue->candidatePeptideStatus_[cnt] == false && score_inactive_peptides == false) 
       continue;
     int xcorr = 0;
     int match_cnt = 0;
@@ -448,22 +446,15 @@ void TideSearchApplication::XCorrScoring(int charge, ObservedPeakSet& observed, 
   
     // Score with single charged b-y ion theoretical peaks
     xcorr += PeakMatching(observed, (*iter)->peaks_0, match_cnt, temp);
-    // // Count the repeating matching ions. This was used in SP scoring
-    // temp = PeakMatching(observed, (*iter)->peaks_1b, temp, repeat_ion_match);
-    // temp = PeakMatching(observed, (*iter)->peaks_1y, temp, repeat_ion_match);
 
     if (charge > 2){
       // Score with double charged b-y ion theoretical peaks
       xcorr += PeakMatching(observed, (*iter)->peaks_1, match_cnt, temp);      
-      // Count the repeating matching ions. This was used in SP scoring      
-      // temp = PeakMatching(observed, (*iter)->peaks_2b, temp, repeat_ion_match);
-      // temp = PeakMatching(observed, (*iter)->peaks_2y, temp, repeat_ion_match);
     }
     psm_scores.psm_scores_[cnt].peptide_itr_ = iter;
     psm_scores.psm_scores_[cnt].ordinal_ = cnt;    
     psm_scores.psm_scores_[cnt].xcorr_score_ = (double)xcorr/XCORR_SCALING;
     psm_scores.psm_scores_[cnt].by_ion_matched_ = match_cnt;
-    // psm_scores.psm_scores_[cnt].repeat_ion_match_ = repeat_ion_match;
     psm_scores.psm_scores_[cnt].active_ = (*iter)->active_;
     psm_scores.psm_scores_[cnt].by_ion_total_ = (*iter)->peaks_0.size();
     if (charge > 2){

--- a/src/app/TideSearchApplication.cpp
+++ b/src/app/TideSearchApplication.cpp
@@ -360,6 +360,9 @@ void TideSearchApplication::spectrum_search(void *threadarg) {
         spectrum->Size() < min_peaks_  ||
         charge < min_precursor_charge_ || 
         charge >max_precursor_charge_ ) {
+        delete spectrum;
+        delete sc;
+      
       continue; 
    }
 
@@ -376,15 +379,31 @@ void TideSearchApplication::spectrum_search(void *threadarg) {
     delete max_mass;
 
     if (active_peptide_queue->nCandPeptides_ == 0) { // No peptides to score.
+      delete spectrum;
+      delete sc;  
       continue; 
     }
+    long num_range_skipped = 0;
+    long num_precursors_skipped = 0;
+    long num_isotopes_skipped = 0;
+    long num_retained = 0;
+
+    ObservedPeakSet observed(use_neutral_loss_peaks_, use_flanking_peaks_);
+    observed.PreprocessSpectrum(*(sc->spectrum), charge, &num_range_skipped,
+      &num_precursors_skipped,
+      &num_isotopes_skipped, &num_retained);
+
     locks_array_[LOCK_CANDIDATES]->lock();
     total_candidate_peptides_ += active_peptide_queue->nCandPeptides_;
     ++num_spectra_searched_;    
+    num_range_skipped_ += num_range_skipped;
+    num_precursors_skipped_ += num_precursors_skipped;
+    num_isotopes_skipped_ += num_isotopes_skipped;
+    num_retained_ += num_retained;
     locks_array_[LOCK_CANDIDATES]->unlock();  
-
+ 
     // allocate PSMscores for N scores
-    TideMatchSet psm_scores(active_peptide_queue);  //nPeptides_ includes acitve and inacitve peptides
+    TideMatchSet psm_scores(active_peptide_queue, &observed);  //nPeptides_ includes acitve and inacitve peptides
 
     // Calculate the scores needed
     switch (curScoreFunction_) {
@@ -393,34 +412,16 @@ void TideSearchApplication::spectrum_search(void *threadarg) {
         //break; // Run standard xcorr scoring in case of combined p-value calculations
       case XCORR_SCORE:
         // Spectrum preprocessing for xcorr scoring
-        long num_range_skipped = 0;
-        long num_precursors_skipped = 0;
-        long num_isotopes_skipped = 0;
-        long num_retained = 0;
-
-        ObservedPeakSet observed(use_neutral_loss_peaks_, use_flanking_peaks_);
-        observed.PreprocessSpectrum(*(sc->spectrum), charge, &num_range_skipped,
-          &num_precursors_skipped,
-          &num_isotopes_skipped, &num_retained);
-
-        locks_array_[LOCK_REPORTING]->lock();
-        num_range_skipped_ += num_range_skipped;
-        num_precursors_skipped_ += num_precursors_skipped;
-        num_isotopes_skipped_ += num_isotopes_skipped;
-        num_retained_ += num_retained;
-        locks_array_[LOCK_REPORTING]->unlock();
-
         XCorrScoring(sc->charge, observed, active_peptide_queue, psm_scores);
         break;
-      // case HYPERSCOR: TODO add noew scoring functinos here
+      // case HYPERSCOR: TODO add new scoring functions here
     } 
     // Print the top-N results to the output files, 
-    // The delta_cn, delta_lcn, and tailor score calulation happens in PrintResults
-
+    // The delta_cn, delta_lcn, repeat_ion_match, and tailor score calculation happens in PrintResults
     PrintResults(sc, spectrum_file_name, input_file_source, &psm_scores);
+
     delete spectrum;
     delete sc;
-
   }
 }
 
@@ -437,31 +438,33 @@ void TideSearchApplication::XCorrScoring(int charge, ObservedPeakSet& observed, 
   for (deque<Peptide*>::const_iterator iter = active_peptide_queue->begin_; 
     iter != active_peptide_queue->end_;
     ++iter, ++cnt) {
-    if (active_peptide_queue->candidatePeptideStatus_[cnt] == false && score_inactive_peptides == false) 
+    if ((*iter)->active_ == false && score_inactive_peptides == false) 
+//      if (active_peptide_queue->candidatePeptideStatus_[cnt] == false && score_inactive_peptides == false) 
       continue;
     int xcorr = 0;
     int match_cnt = 0;
     int temp = 0;
-    int repeat_ion_match = 0;
+    // int repeat_ion_match = 0;
   
     // Score with single charged b-y ion theoretical peaks
     xcorr += PeakMatching(observed, (*iter)->peaks_0, match_cnt, temp);
-    // Count the repeating matching ions. This was used in SP scoring
-    temp = PeakMatching(observed, (*iter)->peaks_1b, temp, repeat_ion_match);
-    temp = PeakMatching(observed, (*iter)->peaks_1y, temp, repeat_ion_match);
+    // // Count the repeating matching ions. This was used in SP scoring
+    // temp = PeakMatching(observed, (*iter)->peaks_1b, temp, repeat_ion_match);
+    // temp = PeakMatching(observed, (*iter)->peaks_1y, temp, repeat_ion_match);
 
     if (charge > 2){
       // Score with double charged b-y ion theoretical peaks
       xcorr += PeakMatching(observed, (*iter)->peaks_1, match_cnt, temp);      
       // Count the repeating matching ions. This was used in SP scoring      
-      temp = PeakMatching(observed, (*iter)->peaks_2b, temp, repeat_ion_match);
-      temp = PeakMatching(observed, (*iter)->peaks_2y, temp, repeat_ion_match);
+      // temp = PeakMatching(observed, (*iter)->peaks_2b, temp, repeat_ion_match);
+      // temp = PeakMatching(observed, (*iter)->peaks_2y, temp, repeat_ion_match);
     }
+    psm_scores.psm_scores_[cnt].peptide_itr_ = iter;
     psm_scores.psm_scores_[cnt].ordinal_ = cnt;    
     psm_scores.psm_scores_[cnt].xcorr_score_ = (double)xcorr/XCORR_SCALING;
     psm_scores.psm_scores_[cnt].by_ion_matched_ = match_cnt;
-    psm_scores.psm_scores_[cnt].repeat_ion_match_ = repeat_ion_match;
-    psm_scores.psm_scores_[cnt].active_ = active_peptide_queue->candidatePeptideStatus_[cnt];  
+    // psm_scores.psm_scores_[cnt].repeat_ion_match_ = repeat_ion_match;
+    psm_scores.psm_scores_[cnt].active_ = (*iter)->active_;
     psm_scores.psm_scores_[cnt].by_ion_total_ = (*iter)->peaks_0.size();
     if (charge > 2){
       psm_scores.psm_scores_[cnt].by_ion_total_ += (*iter)->peaks_1.size();
@@ -537,8 +540,9 @@ void TideSearchApplication::PValueScoring(const SpectrumCollection::SpecCharge* 
       iter != active_peptide_queue->end_; 
       ++iter, ++cnt) {
 
-    if (!active_peptide_queue->candidatePeptideStatus_[cnt])
-      continue;
+      // if (!active_peptide_queue->candidatePeptideStatus_[cnt])
+      if (! (*iter)->active_)
+        continue;
 
     int pepMassIntIdx = 0;
     int curPepMassInt;
@@ -566,7 +570,7 @@ void TideSearchApplication::PValueScoring(const SpectrumCollection::SpecCharge* 
     psm_scores.psm_scores_[cnt].ordinal_ = cnt;
     psm_scores.psm_scores_[cnt].refactored_xcorr_ = scoreRefactInt / RESCALE_FACTOR;
     psm_scores.psm_scores_[cnt].exact_pval_ = pValue_xcorr;
-    psm_scores.psm_scores_[cnt].active_ = active_peptide_queue->candidatePeptideStatus_[cnt];  
+    psm_scores.psm_scores_[cnt].active_ = (*iter)->active_;
   }
 
   // // 2. Calculate the RES-EV SCORE and its RES-EV P-VALUE, developed by Andy Lin
@@ -623,7 +627,7 @@ void TideSearchApplication::PValueScoring(const SpectrumCollection::SpecCharge* 
       iter != active_peptide_queue->end_; 
       ++iter, ++cnt) {
 
-    if (!active_peptide_queue->candidatePeptideStatus_[cnt]) {
+    if (!(*iter)->active_) {
       resEvScores.push_back(-1);
       continue;
     }
@@ -699,7 +703,7 @@ void TideSearchApplication::PValueScoring(const SpectrumCollection::SpecCharge* 
       iter != active_peptide_queue->end_; 
       ++iter, ++cnt) {
 
-    if (!active_peptide_queue->candidatePeptideStatus_[cnt])
+    if (! (*iter)->active_ )
       continue;
 
     int pepMassIntIdx = 0;
@@ -738,7 +742,7 @@ void TideSearchApplication::PValueScoring(const SpectrumCollection::SpecCharge* 
     psm_scores.psm_scores_[cnt].resEv_pval_    = pValue_resEv;
     psm_scores.psm_scores_[cnt].combined_pval_ = pValue_combined;
     psm_scores.psm_scores_[cnt].ordinal_       = cnt;
-    psm_scores.psm_scores_[cnt].active_        = active_peptide_queue->candidatePeptideStatus_[cnt];  
+    psm_scores.psm_scores_[cnt].active_        = (*iter)->active_;  
   }
 }
 
@@ -1802,13 +1806,13 @@ void TideSearchApplication::getMassBin(
   ActivePeptideQueue* active_peptide_queue
 ) {
   int pe = 0;
-  for (deque<Peptide*>::const_iterator iter_ = active_peptide_queue->begin_;
-      iter_ != active_peptide_queue->end_; 
-      ++iter_) {
-    double pepMass = (*iter_)->Mass();
+  for (deque<Peptide*>::const_iterator iter = active_peptide_queue->begin_;
+      iter != active_peptide_queue->end_; 
+      ++iter) {
+    double pepMass = (*iter)->Mass();
     int pepMaInt = MassConstants::mass2bin(pepMass);
     pepMassInt[pe] = pepMaInt;
-    if (active_peptide_queue->candidatePeptideStatus_[pe]) {
+    if ( (*iter)->active_) {
       pepMassIntUnique.push_back(pepMaInt);
     }
     pe++;

--- a/src/app/TideSearchApplication.h
+++ b/src/app/TideSearchApplication.h
@@ -79,9 +79,7 @@ class TideSearchApplication : public CruxApplication {
 
   vector<boost::mutex *> locks_array_;  
 
-  //vector<TideSearchApplication::InputFile> getInputFiles(const vector<string>& filepaths) const;
   void getInputFiles(int thread_id);
-  // static SpectrumCollection* loadSpectra(const std::string& file);
   void getPeptideIndexData(string, ProteinVec& proteins, vector<const pb::AuxLocation*>& locations, pb::Header& peptides_header);
   void createOutputFiles();
 

--- a/src/app/tide/ActivePeptideQueue.cc
+++ b/src/app/tide/ActivePeptideQueue.cc
@@ -109,16 +109,18 @@ int ActivePeptideQueue::SetActiveRange(vector<double>* min_mass, vector<double>*
     return 0;
   }
 
+  nPeptides_ = 0;
   begin_ = queue_.begin();
-  candidatePeptideStatus_.clear();
+  // candidatePeptideStatus_.clear();
   while (begin_ != queue_.end() && (*begin_)->Mass() < min_mass->front()) {
+    (*begin_)->active_ = false;
     ++begin_;
-    candidatePeptideStatus_.push_back(false);  
+    ++nPeptides_;
+    // candidatePeptideStatus_.push_back(false);  
   }
   end_ = begin_;
   begin_ = queue_.begin();
   int* isotope_idx = new int(0);
-  nPeptides_ = 0;
   nCandPeptides_ = 0;
   CandPeptidesTarget_ = 0;
   CandPeptidesDecoy_ = 0;  
@@ -126,14 +128,16 @@ int ActivePeptideQueue::SetActiveRange(vector<double>* min_mass, vector<double>*
   while (end_ != queue_.end() && (*end_)->Mass() < max_mass->back() ) {
     if (isWithinIsotope(min_mass, max_mass, (*end_)->Mass(), isotope_idx)) {
       ++nCandPeptides_;
-      candidatePeptideStatus_.push_back(true);
+      (*end_)->active_ = true;
+//      candidatePeptideStatus_.push_back(true);
       if ((*end_)->IsDecoy()){
         ++CandPeptidesDecoy_;
       } else {
         ++CandPeptidesTarget_;
       }
     } else {
-      candidatePeptideStatus_.push_back(false);
+      (*end_)->active_ = false;
+      // candidatePeptideStatus_.push_back(false);
     }
     ++end_;
     ++nPeptides_;
@@ -143,10 +147,11 @@ int ActivePeptideQueue::SetActiveRange(vector<double>* min_mass, vector<double>*
     return 0;
   }
   for (; end_ != queue_.end(); ++end_) {
-    if ((*end_)->peaks_0.size() == 0 || candidatePeptideStatus_.size() >= min_candidates_-1) {
+    if ((*end_)->peaks_0.size() == 0 || nPeptides_ >= min_candidates_-1) {
       break;
     }
-    candidatePeptideStatus_.push_back(false);
+    (*end_)->active_ = false;
+    // candidatePeptideStatus_.push_back(false);
     ++nPeptides_;
   }
   return nCandPeptides_;

--- a/src/app/tide/ActivePeptideQueue.cc
+++ b/src/app/tide/ActivePeptideQueue.cc
@@ -111,12 +111,10 @@ int ActivePeptideQueue::SetActiveRange(vector<double>* min_mass, vector<double>*
 
   nPeptides_ = 0;
   begin_ = queue_.begin();
-  // candidatePeptideStatus_.clear();
   while (begin_ != queue_.end() && (*begin_)->Mass() < min_mass->front()) {
     (*begin_)->active_ = false;
     ++begin_;
     ++nPeptides_;
-    // candidatePeptideStatus_.push_back(false);  
   }
   end_ = begin_;
   begin_ = queue_.begin();
@@ -129,7 +127,6 @@ int ActivePeptideQueue::SetActiveRange(vector<double>* min_mass, vector<double>*
     if (isWithinIsotope(min_mass, max_mass, (*end_)->Mass(), isotope_idx)) {
       ++nCandPeptides_;
       (*end_)->active_ = true;
-//      candidatePeptideStatus_.push_back(true);
       if ((*end_)->IsDecoy()){
         ++CandPeptidesDecoy_;
       } else {
@@ -137,7 +134,6 @@ int ActivePeptideQueue::SetActiveRange(vector<double>* min_mass, vector<double>*
       }
     } else {
       (*end_)->active_ = false;
-      // candidatePeptideStatus_.push_back(false);
     }
     ++end_;
     ++nPeptides_;
@@ -151,7 +147,6 @@ int ActivePeptideQueue::SetActiveRange(vector<double>* min_mass, vector<double>*
       break;
     }
     (*end_)->active_ = false;
-    // candidatePeptideStatus_.push_back(false);
     ++nPeptides_;
   }
   return nCandPeptides_;

--- a/src/app/tide/ActivePeptideQueue.h
+++ b/src/app/tide/ActivePeptideQueue.h
@@ -34,7 +34,6 @@ class ActivePeptideQueue {
 
   deque<Peptide*> queue_;
   deque<Peptide*>::const_iterator begin_, end_;  
-//  vector<bool> candidatePeptideStatus_;
   int min_candidates_;
   bool dia_mode_;
 

--- a/src/app/tide/ActivePeptideQueue.h
+++ b/src/app/tide/ActivePeptideQueue.h
@@ -24,7 +24,7 @@ class ActivePeptideQueue {
         double min_range, double max_range); 
 
   Peptide* GetPeptide(int index) {
-    return *(begin_ + index);
+    return *(begin_ + index); 
   }
 
   int nPeptides_;
@@ -34,7 +34,7 @@ class ActivePeptideQueue {
 
   deque<Peptide*> queue_;
   deque<Peptide*>::const_iterator begin_, end_;  
-  vector<bool> candidatePeptideStatus_;
+//  vector<bool> candidatePeptideStatus_;
   int min_candidates_;
   bool dia_mode_;
 

--- a/src/app/tide/peptide.h
+++ b/src/app/tide/peptide.h
@@ -137,7 +137,9 @@ class Peptide {
   vector<unsigned int> peaks_1b;   // Single charged b ions
   vector<unsigned int> peaks_1y;   // Single charged y ions
   vector<unsigned int> peaks_2b;   // Double charged b ions
-  vector<unsigned int> peaks_2y;   // Double charged y ions
+  vector<unsigned int> peaks_2y;   // Double charged y ions 
+
+  bool active_;
   
  private:
   template<class W> void AddIons(W* workspace, bool dia_mode = false) ;

--- a/src/app/tide/theoretical_peak_set.h
+++ b/src/app/tide/theoretical_peak_set.h
@@ -93,10 +93,8 @@ class TheoreticalPeakSetBYSparse {
     peaks_[1].clear();
   }
 
-//  void AddYIon(double mass, int charge) {
   void AddYIon(int index_y, int charge) {
       assert(charge <= 2);
-    // int index_y = MassConstants::mass2bin(mass + MassConstants::Y + MASS_PROTON, charge);
     if (index_y >= 0 && index_y < peak_mask_end-1 && !peak_mask[index_y]) {
       peak_mask[index_y] = 1;
       index_y += index_y;
@@ -110,7 +108,6 @@ class TheoreticalPeakSetBYSparse {
 
   void AddBIon(int index_b, int charge) {
     assert(charge <= 2);
-    // int index_b = MassConstants::mass2bin(mass + MassConstants::B + MASS_PROTON, charge);
     if (index_b >= 0 && index_b < peak_mask_end-1 && !peak_mask[index_b]) {
       peak_mask[index_b] = 1;
       index_b += index_b;

--- a/src/app/tide/theoretical_peak_set.h
+++ b/src/app/tide/theoretical_peak_set.h
@@ -93,9 +93,10 @@ class TheoreticalPeakSetBYSparse {
     peaks_[1].clear();
   }
 
-  void AddYIon(double mass, int charge) {
-    assert(charge <= 2);
-    int index_y = MassConstants::mass2bin(mass + MassConstants::Y + MASS_PROTON, charge);
+//  void AddYIon(double mass, int charge) {
+  void AddYIon(int index_y, int charge) {
+      assert(charge <= 2);
+    // int index_y = MassConstants::mass2bin(mass + MassConstants::Y + MASS_PROTON, charge);
     if (index_y >= 0 && index_y < peak_mask_end-1 && !peak_mask[index_y]) {
       peak_mask[index_y] = 1;
       index_y += index_y;
@@ -107,9 +108,9 @@ class TheoreticalPeakSetBYSparse {
     }
   }
 
-  void AddBIon(double mass, int charge) {
+  void AddBIon(int index_b, int charge) {
     assert(charge <= 2);
-    int index_b = MassConstants::mass2bin(mass + MassConstants::B + MASS_PROTON, charge);
+    // int index_b = MassConstants::mass2bin(mass + MassConstants::B + MASS_PROTON, charge);
     if (index_b >= 0 && index_b < peak_mask_end-1 && !peak_mask[index_b]) {
       peak_mask[index_b] = 1;
       index_b += index_b;
@@ -129,29 +130,6 @@ class TheoreticalPeakSetBYSparse {
     int cache_end = 0;
     TheoreticalPeakArr peaks_[2];
 };
-
-// This class is used to store theoretical b ions only
-// for use in exact p-value calculations.
-class TheoreticalPeakSetBIons {
- public:
-  TheoreticalPeakSetBIons() {}
-  explicit TheoreticalPeakSetBIons(int capacity) {
-    unordered_peak_list_.reserve(capacity);
-  }
-  virtual ~TheoreticalPeakSetBIons() {}
-
-  void Clear() { unordered_peak_list_.clear(); }
-  void AddBIon(double mass) {
-    int index = MassConstants::mass2bin(mass, 1);
-    if (index >= 0) {
-      unordered_peak_list_.push_back((unsigned int)index);
-    }
-  }
-  vector<unsigned int> unordered_peak_list_;
-  double binWidth_;   // TODO: This should be removed from here.
-  double binOffset_;  // TODO: This should be removed from here.
-};
-
 
 #endif // THEORETICAL_PEAK_SET_H
 


### PR DESCRIPTION
I reorganized a code in the active peptide queue, and in the theoretical peak generation, so that fewer push_backs are used in loops, making tide-search faster.