### PR TITLE
Output format conversion bug

### DIFF
--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -60,6 +60,7 @@
     </ul>
     <h4>Minor changes</h4>
     <ul>
+      <li>27 Aug 2025: Bug fix in output results format conversion in tide-search.</li>
       <li>23 July 2025: Updated GitHub build actions to use windows-latest and added macos-15.</li>
       <li>23 July 2025: Updated build files to support Visual Studio 2022 and later.</li>
       <li>23 July 2025: Update <code>crux comet</code> parameter default to match Comet 2025.01.1.</li>

--- a/src/app/TideSearchApplication.cpp
+++ b/src/app/TideSearchApplication.cpp
@@ -275,14 +275,6 @@ int TideSearchApplication::main(const vector<string>& input_files, const string 
     ((double)total_candidate_peptides_) /  (double)num_spectra_searched_ );
   carp(CARP_INFO, "%d spectrum-charge combinations loaded, %d spectrum-charge combinations searched. ", num_spectra_, num_spectra_searched_);
   
-  convertResults();
-
-  // Delete temporary spectrumrecords file
- for (vector<TideSearchApplication::InputFile>::iterator original_file_name = inputFiles_.begin(); original_file_name != inputFiles_.end(); ++original_file_name) {
-    carp(CARP_DEBUG, "Deleting %s", (*original_file_name).SpectrumRecords.c_str());
-    remove((*original_file_name).SpectrumRecords.c_str());
-  }
-
   // Delete stuffs
   if (out_tsv_target_ != NULL)
     delete out_tsv_target_;
@@ -296,6 +288,14 @@ int TideSearchApplication::main(const vector<string>& input_files, const string 
     delete out_pin_target_;
   if (out_pin_decoy_ != NULL)
     delete out_pin_decoy_;
+  
+  convertResults();
+
+  // Delete temporary spectrumrecords file
+ for (vector<TideSearchApplication::InputFile>::iterator original_file_name = inputFiles_.begin(); original_file_name != inputFiles_.end(); ++original_file_name) {
+    carp(CARP_DEBUG, "Deleting %s", (*original_file_name).SpectrumRecords.c_str());
+    remove((*original_file_name).SpectrumRecords.c_str());
+  }
 
   return 0;
 }


### PR DESCRIPTION
This is a fix for a bug that happens when the user wants to convert the output format of a search results in tide-search program. 

Tide-search writes the results to a default tab-delimited file format. Then, tide-search wants to convert these results files, but the problem is that the final output is not flushed. And the conversion fails.

The fix involves that the output files needs to be closed before conversion. 

