### PR TITLE
Categorize spectral-counts and other uncategorized parameters

### DIFF
--- a/src/util/Params.cpp
+++ b/src/util/Params.cpp
@@ -2393,6 +2393,7 @@ void Params::Categorize() {
   items.insert("top_count");
   items.insert("e_value_depth");
   items.insert("override-charges");
+  items.insert("elution-window-size");
   AddCategory("Search parameters", items);
 
   items.clear();
@@ -2617,6 +2618,91 @@ void Params::Categorize() {
   AddCategory("param-medic options", items);
 
   items.clear();
+  items.insert("algorithm");
+  items.insert("averagine-mod");
+  items.insert("boxcar-averaging");
+  items.insert("boxcar-filter");
+  items.insert("boxcar-filter-ppm");
+  items.insert("cdm");
+  items.insert("centroided");
+  items.insert("corr");
+  items.insert("depth");
+  items.insert("distribution-area");
+  items.insert("hardklor-algorithm");
+  items.insert("hardklor-data-file");
+  items.insert("hardklor-xml-output");
+  items.insert("instrument");
+  items.insert("isotope-data-file");
+  items.insert("max-charge");
+  items.insert("max-features");
+  items.insert("min-charge");
+  items.insert("mz-max");
+  items.insert("mz-min");
+  items.insert("mz-window");
+  items.insert("mzxml-filter");
+  items.insert("resolution");
+  items.insert("scan-range-max");
+  items.insert("scan-range-min");
+  items.insert("sensitivity");
+  items.insert("signal-to-noise");
+  items.insert("smooth");
+  items.insert("sn-window");
+  items.insert("static-sn");
+  AddCategory("Hardklor options", items);
+
+  items.clear();
+  items.insert("coeff-elution");
+  items.insert("coeff-fragment");
+  items.insert("coeff-precursor");
+  items.insert("coeff-rtdiff");
+  items.insert("coeff-tag");
+  items.insert("coelution-oneside-scans");
+  items.insert("coelution-topk");
+  items.insert("diameter-instrument");
+  items.insert("frag-ppm");
+  items.insert("prec-ppm");
+  items.insert("msamanda-regional-topk");
+  items.insert("predrt-files");
+  items.insert("psm-filter");
+  items.insert("spectra-denoising");
+  AddCategory("DIAmeter options", items);
+
+  items.clear();
+  items.insert("flanking");
+  items.insert("h2o");
+  items.insert("isotope");
+  items.insert("nh3");
+  items.insert("precursor-ions");
+  items.insert("primary-ions");
+  AddCategory("Predicting peptide ions", items);
+
+  items.clear();
+  items.insert("combine-charge-states");
+  items.insert("combine-modified-peptides");
+  items.insert("estimation-method");
+  items.insert("percolator-intraset-features");
+  items.insert("pi-zero");
+  items.insert("score");
+  items.insert("sidak");
+  items.insert("top-match-in");
+  items.insert("use-old-atdc");
+  AddCategory("Assigning confidence / q-value estimation", items);
+
+  items.clear();
+  items.insert("custom-threshold-min");
+  items.insert("custom-threshold-name");
+  items.insert("find-peptides");
+  items.insert("input-ms2");
+  items.insert("measure");
+  items.insert("mzid-use-pass-threshold");
+  items.insert("parsimony");
+  items.insert("quant-level");
+  items.insert("threshold");
+  items.insert("threshold-type");
+  items.insert("unique-mapping");
+  AddCategory("Spectral counts options", items);
+
+  items.clear();
   items.insert("concat");
   items.insert("decoy-prefix");
   items.insert("decoy-xml-output");
@@ -2626,6 +2712,7 @@ void Params::Categorize() {
   items.insert("brief-output");
   items.insert("list-of-files");
   items.insert("mass-precision");
+  items.insert("protein-database");
   items.insert("mzid-output");
   items.insert("num_output_lines");
   items.insert("output-dir");

--- a/src/util/Params.cpp
+++ b/src/util/Params.cpp
@@ -2591,6 +2591,8 @@ void Params::Categorize() {
   items.insert("test-fdr");
   items.insert("train-fdr");
   items.insert("static");
+  items.insert("no-terminate");
+  items.insert("train-best-positive");
   AddCategory("SVM training options", items);
 
   items.clear();
@@ -2600,6 +2602,7 @@ void Params::Categorize() {
   items.insert("output-weights");
   items.insert("override");
   items.insert("unitnorm");
+  items.insert("max-charge-feature");
   AddCategory("SVM feature input options", items);
 
   items.clear();
@@ -2677,6 +2680,11 @@ void Params::Categorize() {
   AddCategory("Predicting peptide ions", items);
 
   items.clear();
+  items.insert("memory-limit");
+  items.insert("auto-modifications-spectra");
+  AddCategory("Tide index options", items);
+
+  items.clear();
   items.insert("combine-charge-states");
   items.insert("combine-modified-peptides");
   items.insert("estimation-method");
@@ -2713,6 +2721,8 @@ void Params::Categorize() {
   items.insert("list-of-files");
   items.insert("mass-precision");
   items.insert("protein-database");
+  items.insert("protein-name-separator");
+  items.insert("spectral-counting-fdr");
   items.insert("mzid-output");
   items.insert("num_output_lines");
   items.insert("output-dir");


### PR DESCRIPTION
## Summary
Builds on #743.

`Params::Categorize()` groups options for the generated docs/param table; anything not explicitly categorized falls into a generic "<command> options" bucket. Audited all ~400 options and found ~115 uncategorized ones.

- Adds **"Spectral counts options"** (the requested category): `custom-threshold-min`, `custom-threshold-name`, `find-peptides`, `input-ms2`, `measure`, `mzid-use-pass-threshold`, `parsimony`, `quant-level`, `threshold`, `threshold-type`, `unique-mapping`.
- Moves `protein-database` into `Input and output` — it's shared by spectral-counts, psm-convert, and tide-search, not spectral-counts-specific.
- Also adds four more categories for the largest unambiguous clusters found during the audit:
  - **Hardklor options** (~30): `algorithm`, `boxcar-*`, `hardklor-*`, `instrument`, `resolution`, `sensitivity`, etc.
  - **DIAmeter options** (~14): `coeff-*`, `coelution-*`, `diameter-instrument`, `prec-ppm`/`frag-ppm`, `psm-filter`, `spectra-denoising`, etc.
  - **Predicting peptide ions** (~6): `flanking`, `h2o`, `isotope`, `nh3`, `precursor-ions`, `primary-ions` (the full set `PredictPeptideIons::getOptions()` declares, minus the two already categorized elsewhere).
  - **Assigning confidence / q-value estimation** (~9): `estimation-method`, `sidak`, `score`, `combine-charge-states`, `combine-modified-peptides`, `top-match-in`, `use-old-atdc`, `percolator-intraset-features`, `pi-zero`.
- Files `elution-window-size` under the existing `Search parameters` category (it's a tide-search/DIA-mode option, not `diameter`-command-specific).

Every option name was cross-checked against `Params::Params()` to confirm it's a real registered parameter, and checked for uniqueness across all categories (each name appears in exactly one category) — `AddCategory()` throws at startup if either check fails, so a mistake here would break every `crux` invocation, not just docs.

**Left for a follow-up, not touched here:** a long tail of smaller one-off options (e.g. `bullseye`/`search-engine` for pipeline, `cascade-termination`/`q-value-threshold` for cascade-search, `distinct-matches`/`input-format` for psm-convert, Kojak/percolator misc options) and a handful of params that are defined but never referenced by any command's `getOptions()` (e.g. `decoy input`, `pm-ignore-no-charge`, `unique-scannr`, `use-tailor-calibration`) — possibly vestigial, worth a separate look.

## Test plan
- [x] `clang++ -fsyntax-only` against the exact CMake-generated flags for this translation unit — compiles clean.
- [x] Verified every newly-added item name exists as a real `Init*Param` call and appears in exactly one category (the two invariants `AddCategory()` enforces at runtime via `CARP_FATAL`/exception).
- [ ] Could not do a full rebuild+run to exercise `Categorize()` at actual startup — this local build directory's ProteoWizard external-project step is currently broken for unrelated, pre-existing reasons (flagged in #743). Recommend CI build/boot-up as the real runtime check before merge.