### PR TITLE
Add lfq as a final step in the pipeline command

### DIFF
--- a/doc/user/release-notes.html
+++ b/doc/user/release-notes.html
@@ -54,6 +54,10 @@
     <h3>Version 5.0.0</h3> April 15, 2026
     <h4>Major changes</h4>
     <ul>
+      <li>24 August 2026: <code>crux pipeline</code> now runs <code>crux lfq</code>
+      as a final label-free quantification step, using the Percolator PSMs and the
+      spectrum files supplied to the pipeline. This runs alongside the existing
+      <code>spectral-counts</code> step.</li>
       <li>5 July 2026: <code>crux pipeline</code> no longer supports
       <code>assign-confidence</code> as a post-processor. The <code>--post-processor</code>
       option has been removed and <code>pipeline</code> now always uses Percolator for

--- a/src/app/Pipeline.cpp
+++ b/src/app/Pipeline.cpp
@@ -9,6 +9,7 @@
 #include "TideSearchApplication.h"
 #include "TideIndexApplication.h"
 #include "CometApplication.h"
+#include "CruxLFQApplication.h"
 #include "SpectralCounts.h"
 
 using namespace std;
@@ -48,6 +49,9 @@ int PipelineApplication::main(int argc, char** argv) {
         break;
       case SPECTRAL_COUNTS_COMMAND:
         ret = runSpectralCounts(cur);
+        break;
+      case CRUX_LFQ_COMMAND:
+        ret = runLFQ(cur, spectra);
         break;
       default:
         carp(CARP_FATAL, "Pipeline is not set up to run command '%s'",
@@ -245,6 +249,30 @@ int PipelineApplication::runSpectralCounts(
   return ((SpectralCounts*)app)->main(filename);
 }
 
+int PipelineApplication::runLFQ(
+  CruxApplication* app,
+  const vector<string>& spectra
+) {
+  if (app->getCommand() != CRUX_LFQ_COMMAND) {
+    carp(CARP_FATAL, "Something went wrong.");
+  }
+
+  string fileroot = Params::GetString("fileroot");
+  if (!fileroot.empty()) {
+    fileroot.append(".");
+  }
+  string psmFile = FileUtils::Join(Params::GetString("output-dir"), fileroot + "percolator.target.psms.txt");
+  string specfileReplicates = Params::GetString("specfile-replicates");
+
+  carp(CARP_INFO, "LFQ will be run using PSM file '%s' and the following spectra files:",
+                  psmFile.c_str());
+  for (vector<string>::const_iterator i = spectra.begin(); i != spectra.end(); i++) {
+    carp(CARP_INFO, "--> %s", i->c_str());
+  }
+
+  return ((CruxLFQApplication*)app)->main(psmFile, spectra, specfileReplicates);
+}
+
 string PipelineApplication::getName() const {
   return "pipeline";
 }
@@ -263,7 +291,8 @@ string PipelineApplication::getDescription() const {
     "provided as a file in FASTA format, or additionally, an index as produced "
     "by <a href=\"tide-index.html\">tide-index</a>.</li><li>Post-processing "
     "using <a href=\"percolator.html\">Percolator</a>.</li><li>Pseudo quantitation "
-    "using <a href=\"spectral-counts.html\">spectral-counts</a></li></ol>"
+    "using <a href=\"spectral-counts.html\">spectral-counts</a></li><li>Label-free "
+    "quantitation using <a href=\"lfq.html\">lfq</a></li></ol>"
     "<p>All of the command line options associated with the individual tools "
     "in the pipeline can be used with the <code>pipeline</code> command.</p>]]";
 }
@@ -289,6 +318,11 @@ vector<string> PipelineApplication::getOptions() const {
   addOptionsFrom<CometApplication>(&options);
   addOptionsFrom<PercolatorApplication>(&options);
   addOptionsFrom<SpectralCounts>(&options);
+  addOptionsFrom<CruxLFQApplication>(&options);
+
+  // Pipeline always feeds LFQ the Percolator PSMs file (see runLFQ()), so
+  // psm-file-format isn't actually a user choice here.
+  removeOptionFrom(&options, "psm-file-format");
 
   return options;
 }
@@ -301,6 +335,7 @@ vector< pair<string, string> > PipelineApplication::getOutputs() const {
   addOutputsFrom<CometApplication>(&outputs);
   addOutputsFrom<PercolatorApplication>(&outputs);
   addOutputsFrom<SpectralCounts>(&outputs);
+  addOutputsFrom<CruxLFQApplication>(&outputs);
 
   return outputs;
 }
@@ -347,6 +382,11 @@ void PipelineApplication::processParams() {
     Params::Set("protein-database", Params::GetString("peptide source"));
   }
   apps_.push_back(new SpectralCounts());
+
+  // Pipeline always post-processes with Percolator, so LFQ must parse its
+  // percolator.target.psms.txt output rather than an assign-confidence file.
+  Params::Set("psm-file-format", "percolator");
+  apps_.push_back(new CruxLFQApplication());
 
   for (vector<CruxApplication*>::iterator i = apps_.begin(); i != apps_.end(); i++) {
     (*i)->processParams();

--- a/src/app/Pipeline.h
+++ b/src/app/Pipeline.h
@@ -37,6 +37,7 @@ class PipelineApplication : public CruxApplication {
   int runPostProcessor(CruxApplication* app,
                        const std::vector<std::string>& resultsFiles);
   int runSpectralCounts(CruxApplication* app);
+  int runLFQ(CruxApplication* app, const std::vector<std::string>& spectra);
 };
 
 #endif

--- a/src/app/crux-lfq/Utils.cpp
+++ b/src/app/crux-lfq/Utils.cpp
@@ -92,7 +92,7 @@ vector<PSM> create_psm(const string& psm_file) {
                                   file_col);
         }
     }else {
-        carp(CARP_FATAL, "PSM file format unknown, the options are assign-confidence and tide-search");
+        carp(CARP_FATAL, "PSM file format unknown, the options are assign-confidence and percolator");
     }
     return psm_data;
 }

--- a/src/util/Params.cpp
+++ b/src/util/Params.cpp
@@ -2270,7 +2270,7 @@ InitStringParam("protein-name-separator", ",",
                 "Indicate whether to normalize the intensities of the peptides (T) or not (F).  Default = F.",
                 "Used by LFQ.", true);
   InitStringParam("psm-file-format", "assign-confidence",
-                  "The format of the PSM file. Possible options are; tide-search and assign-confidence Default = assign-confidence.",
+                  "The format of the PSM file. Possible options are; assign-confidence and percolator. Default = assign-confidence.",
                   "Used by LFQ.", true);
   InitBoolParam("is-rt-seconds", false,
                 "Indicate whether retention time is in seconds or minutes (T) or not (F).  Default = F.",


### PR DESCRIPTION
## Summary
- `crux pipeline` now runs `crux lfq` as a final label-free quantification step, after Percolator and alongside `spectral-counts`
- LFQ is fed the Percolator PSMs (`percolator.target.psms.txt`) and the spectrum files supplied to the pipeline; `pipeline` forces `psm-file-format` to `percolator` internally and hides that option from `pipeline`'s own option list, since it isn't a user choice in this context
- Updated the `psm-file-format` param description (was stale, referencing `tide-search` instead of `percolator`) and the `crux-lfq/Utils.cpp` fatal-error message to match
- Documented the change in the 5.0.0 release notes

## Test plan
- [x] Full CMake build succeeds with no errors
- [x] `crux pipeline` help output shows LFQ options (e.g. `--lfq-q-value-threshold`) and correctly hides `--psm-file-format`
- [x] Standalone `crux lfq` command still exposes `--psm-file-format` normally (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `crux pipeline` now performs label-free quantification as a final step using Percolator PSMs and the supplied spectrum files.
  * Pipeline output and options now include LFQ quantitation alongside spectral counting.

* **Bug Fixes**
  * Updated LFQ validation messages to correctly identify `assign-confidence` and `percolator` as supported PSM formats.

* **Documentation**
  * Added the LFQ pipeline step and behavior to the Version 5.0.0 release notes.
  * Updated LFQ parameter documentation with the supported PSM formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->