### PR TITLE
Updated install guide with info about using ninja build system

### DIFF
--- a/doc/user/tutorials/install.html
+++ b/doc/user/tutorials/install.html
@@ -260,6 +260,27 @@
 		That completes the installation!  Skip ahead to 
 		<a href="#linux_path">Setting the PATH on Linux and MacOS</a>
 		for notes on how to run the executables.
+		<li><b>Optional use of Ninja for building</b></li>
+		<p/>
+		CMake can also use 
+		<a href="https://ninja-build.org">Ninja</a>
+		as the build system.
+		Ninja is an alternative build system which can be used instead of the 
+		default Makefiles,
+		and which can be much faster than Makefiles.
+		To use Ninja for building, first ensure that you have installed the <code>ninja</code> build system.
+		Then, configure the build with the following command:
+		<div class=code><code>
+		cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=&lt;install directory&gt; .
+		</code>
+		</div>
+		<p/>
+		You can then build and install using:
+		<div class=code><code>
+		cmake --build .<br>
+		cmake --build . --target install
+		</code>
+		</div>
 		</ul>
 		<a name="MacOS"></a>
 		<h3>MacOS</h3>
@@ -421,6 +442,26 @@
 		That completes the installation!  Skip ahead to 
 		<a href="#linux_path">Setting the PATH on Linux and MacOS</a>
 		for notes on how to run the executables.
+		<li><b>Optional use of Ninja for building</b></li>
+		<p/>
+		CMake can also use 
+		<a href="https://ninja-build.org">Ninja</a>
+		as the build system.
+		Ninja is an alternative build system which can be used instead of the 
+		default Makefiles,
+		and which can be much faster than Makefiles.
+		To use Ninja for building, first ensure that you have installed the <code>ninja</code> build system.
+		Then, configure the build with the following command:
+		<div class=code><code>
+		cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=&lt;install directory&gt; .
+		</code>
+		</div>
+		<p/>
+		You can then build and install using:
+		<div class=code><code>
+		cmake --build .<br>
+		cmake --build . --target install
+		</code>
 		</ul>
 
 		<a name="linux_path"></a>


### PR DESCRIPTION
Ninja is an alternative to the standard Makefile system. It has the advantage of providing much faster builds and the disadvantage that the actual build scripts are not human interpretable. The later point is moot for the most part because we describe our build in the higher level CMake language anyway.

Our current build works with Ninja for both Linux and MacOS. It does not work for windows. I've added some text describing how to build with Ninja to our install document in both the Linux and MacOS sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added optional Ninja build instructions to the Linux and macOS “Building Crux From Source” tutorials.
  - Documented Ninja installation and the commands for configuring, building, and installing Crux with CMake.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->